### PR TITLE
fix: RecipesPage에서 ref prop을 observerRef로 변경

### DIFF
--- a/src/Pages/RecipesPage.tsx
+++ b/src/Pages/RecipesPage.tsx
@@ -58,7 +58,7 @@ const RecipesPage = () => {
         recipes={recipes}
         isSimple={false}
         hasNextPage={hasNextPage}
-        ref={ref}
+        observerRef={ref}
         noResults={noResults}
         noResultsMessage={noResultsMessage}
       />


### PR DESCRIPTION
RecipesPage 컴포넌트에서 ref prop의 이름을 observerRef로 변경하여 
이전 커밋에서 수정하지 못한 내용을 수정했습니다.