### PR TITLE
feat: 캘린더 상세 페이지에서 레시피 클릭 시 네비게이션 추가 및 텍스트 수정

### DIFF
--- a/src/Pages/CalendarDetailPage.tsx
+++ b/src/Pages/CalendarDetailPage.tsx
@@ -35,6 +35,7 @@ const CalendarDetailPage = () => {
         {data?.map((item) => (
           <div
             key={item.recipeId}
+            onClick={() => navigate(`/recipes/${item.recipeId}`)}
             className="flex items-center gap-4 rounded-2xl border-1 border-gray-200 p-4 py-2"
           >
             <SuspenseImage
@@ -45,11 +46,9 @@ const CalendarDetailPage = () => {
             <div className="flex flex-col gap-2">
               <h1 className="text-lg font-bold">{item.recipeTitle}</h1>
               <div className="flex flex-col">
-                <p className="text-sm text-slate-500">
-                  이 레시피를 만드는 데에
-                </p>
+                <p className="text-sm text-slate-500">이 레시피로</p>
                 <p className="text-olive-mint text-mm font-semibold">
-                  {formatPrice(item.savings)}원이 필요해요
+                  {formatPrice(item.savings)}원을 절약했어요
                 </p>
               </div>
             </div>


### PR DESCRIPTION
캘린더 상세 페이지에서 레시피 항목을 클릭하면 해당 레시피의 상세 페이지로 이동하도록 네비게이션 기능을 추가하였으며, 레시피 절약 금액 표시 문구를 '절약했어요'로 수정하여 사용자에게 더 명확한 정보를 제공하도록 개선하였습니다.