### PR TITLE
feat: AI 레시피 페이지에 인분 조절 기능 추가 및 UI 개선

### DIFF
--- a/src/Pages/AIRecipePage.tsx
+++ b/src/Pages/AIRecipePage.tsx
@@ -1,5 +1,5 @@
 import { useForm } from 'react-hook-form';
-import { ChefHat, Clock, Tag } from 'lucide-react';
+import { ChefHat, Clock, Tag, User } from 'lucide-react';
 import IngredientSelector from '@/Pages/NewRecipe/IngredientSelector';
 import SelectionSection from '@/components/SelectionSection';
 import IngredientSection from '@/components/IngredientSection';
@@ -18,6 +18,7 @@ import LoadingSection from './AIRecipe/LoadingSection';
 import { DISH_TYPES, FOUR_CUT_IMAGE } from '@/constants/recipe';
 import AIRecipeDisplay from './AIRecipe/AIRecipeDisplay';
 import SuspenseImage from '@/components/Image/SuspenseImage';
+import SelectButton from '@/components/SelectButton';
 
 type AIRecipeFormData = AIRecommendedRecipeRequest;
 
@@ -73,12 +74,13 @@ const AIRecipePage = () => {
       dishType: '',
       cookingTime: '',
       tagNames: [],
+      servings: 2,
     },
     mode: 'onChange',
   });
 
   const formValues = watch();
-  const { ingredients, dishType, cookingTime, tagNames } = formValues;
+  const { ingredients, dishType, cookingTime, tagNames, servings } = formValues;
 
   const handleAddIngredient = (ingredientPayload: IngredientPayload) => {
     const newIngredients = [...ingredients, ingredientPayload.name];
@@ -101,6 +103,22 @@ const AIRecipePage = () => {
       shouldValidate: true,
       shouldDirty: true,
     });
+  };
+
+  const handleIncrementServings = () => {
+    setValue('servings', servings + 1, {
+      shouldValidate: true,
+      shouldDirty: true,
+    });
+  };
+
+  const handleDecrementServings = () => {
+    if (servings > 1) {
+      setValue('servings', servings - 1, {
+        shouldValidate: true,
+        shouldDirty: true,
+      });
+    }
   };
 
   const toggle = <T,>(
@@ -134,14 +152,12 @@ const AIRecipePage = () => {
   const toggleTime = (cookingTime: string) =>
     radioToggle('cookingTime', cookingTime);
 
-  const toggleTag = (tag: string) => toggle('tagNames', tagNames, tag);
-
   const totalSteps = 4;
   const completedSteps = [
     ingredients.length > 0,
     dishType.length > 0,
     cookingTime.length > 0,
-    tagNames.length > 0,
+    servings > 0,
   ].filter(Boolean).length;
 
   const progressPercentage = Math.floor((completedSteps / totalSteps) * 100);
@@ -261,17 +277,34 @@ const AIRecipePage = () => {
               isSingleSelect={true}
             />
 
-            <SelectionSection
-              title="태그"
-              icon={<Tag size={18} />}
-              items={recommendedTags}
-              selectedItems={tagNames}
-              onToggle={toggleTag}
-              className="border-b-0"
-            />
+            <div className="mb-3 flex items-center gap-2">
+              <span className="text-olive-mint">
+                <User size={18} />
+              </span>
+              <h2 className="text-lg font-semibold text-gray-800">인분</h2>
+            </div>
+            <div className="flex items-center justify-center gap-4">
+              <button
+                type="button"
+                onClick={handleDecrementServings}
+                className="flex h-8 w-8 items-center justify-center rounded-full bg-gray-200 text-lg text-gray-600 transition-colors hover:bg-gray-300 disabled:opacity-50"
+                disabled={servings <= 1}
+              >
+                -
+              </button>
+              <span className="w-20 text-center font-medium text-gray-800">
+                {servings}인분
+              </span>
+              <button
+                type="button"
+                onClick={handleIncrementServings}
+                className="flex h-8 w-8 items-center justify-center rounded-full bg-gray-200 text-lg text-gray-600 transition-colors hover:bg-gray-300"
+              >
+                +
+              </button>
+            </div>
           </div>
         </div>
-
         <ProgressButton
           progressPercentage={progressPercentage}
           isFormValid={isFormReady && isDirty}

--- a/src/Pages/Home/OnboardingSurveyModal.tsx
+++ b/src/Pages/Home/OnboardingSurveyModal.tsx
@@ -27,7 +27,7 @@ export const OnboardingSurveyModal = ({
   const [answers, setAnswers] = useState<Record<number, string>>({});
   const { user } = useUserStore();
 
-  const handleRadioChange = (value: string) => {
+  const handleValueChange = (value: string) => {
     setAnswers((prevAnswers) => ({
       ...prevAnswers,
       [surveySteps[currentStep].id]: value,
@@ -84,7 +84,7 @@ export const OnboardingSurveyModal = ({
         <SurveyContent
           currentStep={currentStep}
           answers={answers}
-          handleRadioChange={handleRadioChange}
+          handleValueChange={handleValueChange}
         />
         <DialogFooter>
           <button

--- a/src/Pages/Home/SurveyContent.tsx
+++ b/src/Pages/Home/SurveyContent.tsx
@@ -8,7 +8,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 type SurveyContentProps = {
   currentStep: number;
   answers: Record<number, string>;
-  handleRadioChange: (value: string) => void;
+  handleValueChange: (value: string) => void;
 };
 
 const slideVariants = {
@@ -29,7 +29,7 @@ const slideVariants = {
 const SurveyContent = ({
   currentStep,
   answers,
-  handleRadioChange,
+  handleValueChange,
 }: SurveyContentProps) => {
   const currentQuestionData = surveySteps[currentStep];
 
@@ -56,20 +56,36 @@ const SurveyContent = ({
             <RadioGroup
               id={`question-${currentQuestionData.id}`}
               value={answers[currentQuestionData.id] || ''}
-              onValueChange={handleRadioChange}
+              onValueChange={handleValueChange}
               className="grid gap-2"
             >
-              {currentQuestionData.options.map((option) => (
-                <div key={option.value} className="flex items-center space-x-2">
-                  <RadioGroupItem
-                    value={option.value}
-                    id={`${currentQuestionData.id}-${option.value}`}
+              {currentQuestionData.isRadio ? (
+                currentQuestionData.options?.map((option) => (
+                  <div
+                    key={option.value}
+                    className="flex items-center space-x-2"
+                  >
+                    <RadioGroupItem
+                      value={option.value}
+                      id={`${currentQuestionData.id}-${option.value}`}
+                    />
+                    <Label
+                      htmlFor={`${currentQuestionData.id}-${option.value}`}
+                    >
+                      {option.label}
+                    </Label>
+                  </div>
+                ))
+              ) : (
+                <div className="flex flex-col items-center justify-center gap-2">
+                  <textarea
+                    id={`question-${currentQuestionData.id}`}
+                    value={answers[currentQuestionData.id] || ''}
+                    onChange={(e) => handleValueChange(e.target.value)}
+                    className="w-full rounded-md border border-gray-300 p-2 focus:outline-none"
                   />
-                  <Label htmlFor={`${currentQuestionData.id}-${option.value}`}>
-                    {option.label}
-                  </Label>
                 </div>
-              ))}
+              )}
             </RadioGroup>
           </>
         )}

--- a/src/Pages/IngredientsPage/IngredientsPage.tsx
+++ b/src/Pages/IngredientsPage/IngredientsPage.tsx
@@ -80,8 +80,6 @@ const IngredientsPage = () => {
               scrollTrigger: {
                 trigger: gridAnimateTargetRef.current,
                 start: 'top 85%',
-                markers: true,
-
                 toggleActions: 'play none none none',
               },
 

--- a/src/Pages/UserPage/ActionButton.tsx
+++ b/src/Pages/UserPage/ActionButton.tsx
@@ -5,9 +5,14 @@ import { useNavigate } from 'react-router';
 type ActionButtonProps = {
   isLoggedIn: boolean;
   isOwnProfile: boolean;
+  isGuest: boolean;
 };
 
-const ActionButton = ({ isLoggedIn, isOwnProfile }: ActionButtonProps) => {
+const ActionButton = ({
+  isLoggedIn,
+  isOwnProfile,
+  isGuest,
+}: ActionButtonProps) => {
   const navigate = useNavigate();
   const handleLoginClick = () => {
     navigate('/login');
@@ -17,11 +22,13 @@ const ActionButton = ({ isLoggedIn, isOwnProfile }: ActionButtonProps) => {
     navigate('/recipes/new');
   };
 
-  if (!isOwnProfile) {
+  console.log(isGuest, isOwnProfile, isLoggedIn);
+
+  if (!isOwnProfile && !isGuest) {
     return <></>;
   }
 
-  if (!isLoggedIn) {
+  if (!isLoggedIn && isGuest) {
     return (
       <Button
         className="bg-olive-medium hover:bg-olive-dark rounded-full px-6 text-white"

--- a/src/Pages/UserPage/UserDetailPage.tsx
+++ b/src/Pages/UserPage/UserDetailPage.tsx
@@ -55,6 +55,7 @@ const UserDetailPage = () => {
           <ActionButton
             isLoggedIn={!!loggedInUser}
             isOwnProfile={isOwnProfile}
+            isGuest={displayUser.id === guestUser.id}
           />
         </div>
 

--- a/src/api/recipe.ts
+++ b/src/api/recipe.ts
@@ -343,6 +343,7 @@ export type AIRecommendedRecipeRequest = {
   dishType: string;
   cookingTime: string;
   tagNames: string[];
+  servings: number;
 };
 
 export const postAIRecommendedRecipe = async (

--- a/src/components/IngredientSection.tsx
+++ b/src/components/IngredientSection.tsx
@@ -16,14 +16,14 @@ const IngredientSection = ({
   return (
     <div className="mb-6">
       <div
-        className="hover:bg-olive-light/80 border-olive-light flex cursor-pointer items-center justify-center rounded-xl border-2 border-dashed bg-[#f7f7f7] p-5 transition-all duration-300"
+        className="hover:bg-olive-mint/80 border-olive-mint flex cursor-pointer items-center justify-center rounded-xl border-2 border-dashed bg-[#f7f7f7] p-5 transition-all duration-300"
         onClick={onOpenDrawer}
       >
         <div className="flex flex-col items-center">
           <div className="mb-2 rounded-full bg-white p-3 shadow-md">
-            <Plus size={24} className="text-olive-light" />
+            <Plus size={24} className="text-olive-mint" />
           </div>
-          <span className="text-olive-light font-medium">재료 추가하기</span>
+          <span className="text-olive-mint font-medium">재료 추가하기</span>
           <span className="mt-1 text-sm text-gray-500">
             {ingredients.length > 0
               ? `${ingredients.length}개의 재료가 추가됨`
@@ -33,9 +33,9 @@ const IngredientSection = ({
       </div>
 
       {ingredients.length > 0 && (
-        <div className="mt-4 rounded-lg bg-green-50 p-4">
+        <div className="bg-olive-mint/10 mt-4 rounded-lg p-4">
           <div className="mb-2 flex items-center justify-between">
-            <h3 className="text-sm font-medium text-green-800">선택된 재료</h3>
+            <h3 className="text-olive-mint text-sm font-medium">선택된 재료</h3>
             {ingredients.length > 1 && (
               <button
                 onClick={(e) => {

--- a/src/components/ProgressButton.tsx
+++ b/src/components/ProgressButton.tsx
@@ -28,7 +28,7 @@ const ProgressButton = ({
       <div className="absolute inset-0 bg-gray-300"></div>
 
       <div
-        className="bg-olive-light absolute inset-y-0 left-0 transition-all duration-700 ease-out group-hover:brightness-110"
+        className="bg-olive-mint absolute inset-y-0 left-0 transition-all duration-700 ease-out group-hover:brightness-110"
         style={{ width: `${progressPercentage}%` }}
       ></div>
 

--- a/src/components/SelectButton.tsx
+++ b/src/components/SelectButton.tsx
@@ -23,7 +23,7 @@ const SelectButton = ({
       className={cn(
         'flex cursor-pointer items-center gap-1.5 rounded-full transition-all duration-100 hover:border-green-700',
         isSelected
-          ? 'bg-olive-light border-olive-light hover:bg-olive-light hover:border-olive-light text-white hover:text-white'
+          ? 'bg-olive-mint border-olive-mint hover:bg-olive-mint hover:border-olive-mint text-white hover:text-white'
           : 'border-gray-300',
         className,
       )}

--- a/src/components/SelectionSection.tsx
+++ b/src/components/SelectionSection.tsx
@@ -23,7 +23,7 @@ const SelectionSection = ({
   return (
     <div className={`border-b pb-5 ${className}`}>
       <div className="mb-3 flex items-center gap-2">
-        <span className="text-olive">{icon}</span>
+        <span className="text-olive-mint">{icon}</span>
         <h2 className="text-lg font-semibold text-gray-800">{title}</h2>
       </div>
       <div className="flex flex-wrap gap-2">

--- a/src/constants/user.ts
+++ b/src/constants/user.ts
@@ -30,7 +30,8 @@ export const OtherTabs: Tab[] = [
 interface SurveyStep {
   id: number;
   question: string;
-  options: { value: string; label: string }[];
+  options?: { value: string; label: string }[];
+  isRadio: boolean;
 }
 
 export const surveySteps: SurveyStep[] = [
@@ -44,17 +45,12 @@ export const surveySteps: SurveyStep[] = [
       { value: 'dessert', label: '디저트' },
       { value: 'drink', label: '음료' },
     ],
+    isRadio: true,
   },
   {
     id: 2,
-    question: '어떤 종류의 영화를 가장 좋아하시나요?',
-    options: [
-      { value: 'action', label: '액션' },
-      { value: 'comedy', label: '코미디' },
-      { value: 'drama', label: '드라마' },
-      { value: 'thriller', label: '스릴러' },
-      { value: 'sf', label: 'SF' },
-    ],
+    question: '알레르기가 있는 음식이 있나요? 있다면 알려주세요.',
+    isRadio: false,
   },
   {
     id: 3,
@@ -65,5 +61,6 @@ export const surveySteps: SurveyStep[] = [
       { value: 'dislike', label: ' 싫어함' },
       { value: 'hate', label: ' 못 먹음' },
     ],
+    isRadio: true,
   },
 ];


### PR DESCRIPTION
AI 레시피 페이지에서 인분 수를 조절할 수 있는 기능을 추가하였으며, 관련 UI 요소를 개선하여 사용자 경험을 향상시켰습니다. 또한, 서브 컴포넌트에서 사용되는 props 이름을 변경하여 코드의 가독성을 높였습니다. 이를 통해 UI의 일관성을 강화하고, 사용자 인터페이스의 편리함을 증대시켰습니다.