### PR TITLE
feat: 레시피 상세 페이지 및 쿼리 관련 수정

### DIFF
--- a/src/Pages/RecipeDetailPage.tsx
+++ b/src/Pages/RecipeDetailPage.tsx
@@ -27,8 +27,8 @@ const RecipeDetailPage = () => {
   const imageRef = useRef<HTMLImageElement>(null);
   const observerRef = useRef<HTMLDivElement>(null);
 
-  const { id } = useParams();
-  const { recipeData: recipe } = useRecipeDetailQuery(Number(id));
+  const { recipeId } = useParams();
+  const { recipeData: recipe } = useRecipeDetailQuery(Number(recipeId));
 
   const { mutate: toggleFavorite } = useToggleRecipeFavorite(recipe.id);
   const { addToast } = useToastStore();

--- a/src/components/comment/CommentLikeButton.tsx
+++ b/src/components/comment/CommentLikeButton.tsx
@@ -11,7 +11,6 @@ type CommentLikeButtonProps = {
 
 const CommentLikeButton = ({
   commentId,
-
   initialIsLiked,
   initialLikeCount,
 }: CommentLikeButtonProps) => {

--- a/src/hooks/useLikeCommentMutation.ts
+++ b/src/hooks/useLikeCommentMutation.ts
@@ -78,6 +78,7 @@ export const useLikeCommentMutation = (
 
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: commentsListQueryKey });
+      queryClient.invalidateQueries({ queryKey: ['recipe', recipeId] });
 
       queryClient.invalidateQueries({ queryKey: commentQueryKey });
     },

--- a/src/hooks/useRecipeDetailQuery.ts
+++ b/src/hooks/useRecipeDetailQuery.ts
@@ -10,7 +10,7 @@ const useRecipeDetailQuery = (id: number) => {
     error,
     refetch,
   } = useSuspenseQuery<Recipe, Error>({
-    queryKey: ['recipe', id],
+    queryKey: ['recipe', id.toString()],
     queryFn: () => getRecipe(id),
     retry: false,
   });

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -73,7 +73,7 @@ const router = createBrowserRouter([
         element: <DiscussionPage />,
       },
       {
-        path: 'recipes/:id',
+        path: 'recipes/:recipeId',
         element: <RecipeDetailPage />,
       },
       {


### PR DESCRIPTION
레시피 상세 페이지에서 URL 파라미터 이름을 'id'에서 'recipeId'로 변경하였으며, 레시피 쿼리 키를 문자열로 변환하여 일관성을 높였습니다. 또한, 댓글 좋아요 뮤테이션 후 관련 레시피 쿼리를 무효화하여 데이터 일관성을 강화하였습니다. 이를 통해 코드의 가독성을 높이고 사용자 경험을 향상시켰습니다.