### PR TITLE
feat: PWA 지원을 위한 서비스 워커 및 매니페스트 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,14 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <link rel="manifest" href="/manifest.json" />
+    <meta name="theme-color" content="#58C16A" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="apple-mobile-web-app-title" content="해먹" />
+    <link rel="apple-touch-icon" href="/logo.svg" />
+
     <title>해먹</title>
   </head>
   <body>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,29 @@
+{
+  "name": "해먹: AI 레시피",
+  "short_name": "해먹",
+  "description": "AI와 함께하는 레시피 추천 서비스",
+  "icons": [
+    {
+      "src": "/logo.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "/logo.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "/logo.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ],
+  "start_url": "/",
+  "display": "standalone",
+  "scope": "/",
+  "background_color": "#ffffff",
+  "theme_color": "#58C16A"
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,57 @@
+const CACHE_NAME = 'travel-helper-v1';
+const FILES_TO_CACHE = ['/', '/index.html', '/manifest.json', '/logo.svg'];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => {
+      return cache.addAll(FILES_TO_CACHE);
+    }),
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((cacheNames) => {
+      return Promise.all(
+        cacheNames.map((cacheName) => {
+          if (cacheName !== CACHE_NAME) {
+            console.log('오래된 캐시 삭제:', cacheName);
+            return caches.delete(cacheName);
+          }
+        }),
+      );
+    }),
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', (event) => {
+  event.respondWith(
+    caches.match(event.request).then((response) => {
+      return response || fetch(event.request);
+    }),
+  );
+});
+
+// 메인 앱으로부터 메시지 처리
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+
+  if (event.data && event.data.type === 'UPDATE_CACHE') {
+    event.waitUntil(updateCache());
+  }
+});
+
+// 캐시 업데이트 함수
+async function updateCache() {
+  try {
+    const cache = await caches.open(CACHE_NAME);
+    await cache.addAll(FILES_TO_CACHE);
+    console.log('캐시가 업데이트되었습니다.');
+  } catch (error) {
+    console.error('캐시 업데이트 실패:', error);
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,13 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App';
+import { registerServiceWorker } from './utils/serviceWorker';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />
   </StrictMode>,
 );
+
+// 앱 렌더링 후 서비스 워커 등록
+registerServiceWorker();

--- a/src/utils/serviceWorker.ts
+++ b/src/utils/serviceWorker.ts
@@ -1,0 +1,67 @@
+// 서비스 워커 등록 및 관리 유틸리티
+
+export const registerServiceWorker = async () => {
+  if (!('serviceWorker' in navigator)) {
+    console.log('이 브라우저는 서비스 워커를 지원하지 않습니다.');
+    return;
+  }
+
+  // 개발 환경에서는 서비스 워커를 등록하지 않음
+  if (!import.meta.env.PROD) {
+    console.log('개발 환경에서는 서비스 워커가 등록되지 않습니다.');
+    return;
+  }
+
+  try {
+    const registration = await navigator.serviceWorker.register('/sw.js', {
+      scope: '/',
+    });
+
+    console.log('서비스 워커 등록 성공:', registration);
+
+    // 서비스 워커 업데이트 감지
+    registration.addEventListener('updatefound', () => {
+      const newWorker = registration.installing;
+      if (!newWorker) return;
+
+      newWorker.addEventListener('statechange', () => {
+        if (newWorker.state === 'installed') {
+          if (navigator.serviceWorker.controller) {
+            // 기존 서비스 워커가 있고 새 버전이 설치됨 - 자동 업데이트
+            console.log('새 버전이 감지되었습니다. 자동으로 업데이트합니다.');
+            skipWaiting();
+            window.location.reload();
+          } else {
+            // 첫 번째 설치
+            console.log('앱이 오프라인에서도 사용 가능합니다.');
+          }
+        }
+      });
+    });
+
+    // 서비스 워커가 컨트롤러 역할을 시작할 때
+    if (registration.waiting) {
+      console.log('새 버전이 대기 중입니다. 자동으로 업데이트합니다.');
+      skipWaiting();
+      window.location.reload();
+    }
+
+    return registration;
+  } catch (error) {
+    console.error('서비스 워커 등록 실패:', error);
+  }
+};
+
+// 서비스 워커 업데이트 강제 적용
+export const skipWaiting = () => {
+  if ('serviceWorker' in navigator && navigator.serviceWorker.controller) {
+    navigator.serviceWorker.controller.postMessage({ type: 'SKIP_WAITING' });
+  }
+};
+
+// 캐시 수동 업데이트
+export const updateCache = async () => {
+  if ('serviceWorker' in navigator && navigator.serviceWorker.controller) {
+    navigator.serviceWorker.controller.postMessage({ type: 'UPDATE_CACHE' });
+  }
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,4 +11,12 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
     },
   },
+  build: {
+    rollupOptions: {
+      input: {
+        main: 'index.html',
+      },
+    },
+  },
+  publicDir: 'public',
 });


### PR DESCRIPTION
웹 애플리케이션의 PWA(Progressive Web App) 지원을 위해 서비스 워커와 매니페스트 파일을 추가하였습니다. 이를 통해 오프라인 사용 및 홈 화면 추가 기능을 지원하며, 사용자 경험을 향상시키고 앱의 접근성을 높였습니다. 또한, index.html 파일에 관련 메타 태그를 추가하여 앱의 테마 색상 및 아이콘을 설정하였습니다.