### PR TITLE
fix: PageTransition 컴포넌트의 import 구문 정렬 및 타입 선언 수정

### DIFF
--- a/src/app/providers/PageTransition.tsx
+++ b/src/app/providers/PageTransition.tsx
@@ -3,7 +3,7 @@
 import { useLayoutEffect, useRef } from "react";
 import { usePathname } from "next/navigation";
 
-import { AnimatePresence,motion } from "framer-motion";
+import { AnimatePresence, motion } from "framer-motion";
 
 import { useScrollContext } from "@/shared/lib/ScrollContext";
 
@@ -23,7 +23,7 @@ const pageTransition = {
   type: "tween",
   ease: "easeIn",
   duration: 0.25,
-};
+} as const;
 
 export const PageTransition = ({ children }: { children: React.ReactNode }) => {
   const pathname = usePathname();


### PR DESCRIPTION
- `framer-motion`의 import 구문을 정렬하여 가독성을 향상시켰습니다.
- `pageTransition` 객체의 타입을 `as const`로 명시하여 타입 안정성을 높였습니다.