### PR TITLE
fix: API 리다이렉트 경로 수정

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -12,7 +12,7 @@ const nextConfig = withPWA({
     return [
       {
         source: "/api/:path*",
-        destination: "https://api.haemeok.com/:path*",
+        destination: "https://api.haemeok.com/api/:path*",
       },
       {
         source: "/ws/:path*",


### PR DESCRIPTION
- `next.config.ts` 파일에서 API 리다이렉트 경로를 수정하여 `/api/:path*`에서 `https://api.haemeok.com/api/:path*`로 변경하였습니다.
- 이 변경으로 API 호출의 일관성을 높이고, 올바른 엔드포인트로의 요청을 보장합니다.