### PR TITLE
feat: 레시피 카테고리 페이지 및 검색 기능 개선

### DIFF
--- a/src/app/recipes/category/[id]/page.tsx
+++ b/src/app/recipes/category/[id]/page.tsx
@@ -17,8 +17,8 @@ import { DetailedRecipesApiResponse } from "@/entities/recipe";
 import RecipeGrid from "@/widgets/RecipeGrid/ui/RecipeGrid";
 
 const CategoryDetailPage = () => {
-  const { categorySlug: tagCode } = useParams<{ categorySlug: TagCode }>();
-  const router = useRouter();
+  const { id: tagCode } = useParams<{ id: TagCode }>();
+
   const { data, hasNextPage, isFetching, ref } = useInfiniteScroll<
     DetailedRecipesApiResponse,
     Error,
@@ -36,11 +36,6 @@ const CategoryDetailPage = () => {
     getNextPageParam: getNextPageParam,
     initialPageParam: 0,
   });
-
-  if (!tagCode) {
-    router.push("/");
-    return;
-  }
 
   const tagName = TAG_CODES_TO_NAME[tagCode as keyof typeof TAG_CODES_TO_NAME];
 

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -31,9 +31,7 @@ export async function generateMetadata({
   };
 }
 
-// 2. 페이지는 서버 컴포넌트로, searchParams를 받습니다.
 export default async function SearchPage({ searchParams }: SearchPageProps) {
-  // 3. 서버에서 URL 쿼리 파라미터를 사용해 초기 데이터를 가져옵니다.
   const awaitedSearchParams = await searchParams;
   const tagNames = Array.isArray(awaitedSearchParams.tagNames)
     ? awaitedSearchParams.tagNames
@@ -49,8 +47,5 @@ export default async function SearchPage({ searchParams }: SearchPageProps) {
     tagNames,
   });
 
-  return (
-    // 4. 모든 상호작용은 클라이언트 컴포넌트에 위임하고, 서버에서 가져온 데이터를 전달합니다.
-    <SearchClient initialRecipes={initialRecipes} />
-  );
+  return <SearchClient initialRecipes={initialRecipes} />;
 }

--- a/src/features/edit-user-profile/ui/UserInfoEditButton.tsx
+++ b/src/features/edit-user-profile/ui/UserInfoEditButton.tsx
@@ -14,7 +14,7 @@ const UserInfoEditButton = ({ className = "" }: UserInfoEditButtonProps) => {
   const router = useRouter();
   return (
     <div
-      onClick={() => router.push("/user/info")}
+      onClick={() => router.push("/users/edit")}
       className={cn(
         "bg-olive-light absolute -right-1 -bottom-1 flex h-8 w-8 cursor-pointer items-center justify-center rounded-full shadow-md",
         className

--- a/src/shared/config/constants/recipe.ts
+++ b/src/shared/config/constants/recipe.ts
@@ -86,6 +86,10 @@ export const DISH_TYPE_CODES = {
   "디저트/간식류": "DESSERT",
 };
 
+export const DISH_TYPE_CODES_TO_NAME = Object.fromEntries(
+  Object.entries(DISH_TYPE_CODES).map(([key, value]) => [value, key])
+);
+
 export const TAGS = [
   "홈파티",
   "피크닉",

--- a/src/widgets/CategoryDrawer/CategoryDrawer.tsx
+++ b/src/widgets/CategoryDrawer/CategoryDrawer.tsx
@@ -40,6 +40,7 @@ const CategoryDrawer = ({
   const [internalSelection, setInternalSelection] = useState<string[] | string>(
     initialValue
   );
+  console.log(internalSelection, initialValue);
 
   useEffect(() => {
     if (open) {

--- a/src/widgets/Header/HomeHeader.tsx
+++ b/src/widgets/Header/HomeHeader.tsx
@@ -6,7 +6,6 @@ const HomeHeader = () => {
   return (
     <div className="px-6 pt-6 pb-3 backdrop-blur-md">
       <div className="mb-2 flex items-center justify-between">
-        {/* 로고 영역 */}
         <div className="flex items-center gap-2">
           <Image
             src="/logo.svg"
@@ -18,7 +17,6 @@ const HomeHeader = () => {
           <p className="text-2xl font-bold">Haemeok</p>
         </div>
 
-        {/* 알림 드롭다운 */}
         <NotificationDropdown />
       </div>
     </div>

--- a/src/widgets/SearchClient/components/SearchFilters.tsx
+++ b/src/widgets/SearchClient/components/SearchFilters.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { Search } from "lucide-react";
 
 import FilterChip from "@/shared/ui/FilterChip";
+import { TAG_EMOJI } from "@/shared/config/constants/recipe";
 
 type SearchFiltersProps = {
   inputValue: string;
@@ -27,6 +28,9 @@ export const SearchFilters = ({
   onSortClick,
   onTagsClick,
 }: SearchFiltersProps) => {
+  const tagNamesWithEmoji = tagNames.map(
+    (tag) => `${TAG_EMOJI[tag as keyof typeof TAG_EMOJI]} ${tag}`
+  );
   return (
     <div className="sticky top-0 z-10 border-b border-gray-200 bg-white p-4 pb-0">
       <form onSubmit={handleSearchSubmit} className="relative">
@@ -58,7 +62,7 @@ export const SearchFilters = ({
           isDirty={sort !== "최신순"}
         />
         <FilterChip
-          header={tagNames.length > 0 ? tagNames.join(", ") : "태그"}
+          header={tagNames.length > 0 ? tagNamesWithEmoji.join(", ") : "태그"}
           onClick={onTagsClick}
           isDirty={tagNames.length > 0}
         />

--- a/src/widgets/SearchClient/hooks/useSearchDrawer.ts
+++ b/src/widgets/SearchClient/hooks/useSearchDrawer.ts
@@ -3,6 +3,7 @@ import { useState } from "react";
 import {
   BASE_DRAWER_CONFIGS,
   DrawerType,
+  TAG_EMOJI,
 } from "@/shared/config/constants/recipe";
 
 type DrawerConfig = {
@@ -45,7 +46,9 @@ export const useSearchDrawer = ({
       setState: updateSort,
     },
     tags: {
-      state: tagNames,
+      state: tagNames.map(
+        (tag) => `${TAG_EMOJI[tag as keyof typeof TAG_EMOJI]} ${tag}`
+      ),
       setState: updateTags,
     },
   };

--- a/src/widgets/SearchClient/hooks/useSearchResults.ts
+++ b/src/widgets/SearchClient/hooks/useSearchResults.ts
@@ -5,6 +5,10 @@ import { getNextPageParam } from "@/shared/lib/utils";
 
 import { getRecipeItems } from "@/entities/recipe";
 import { DetailedRecipesApiResponse } from "@/entities/recipe";
+import {
+  DISH_TYPE_CODES,
+  DISH_TYPE_CODES_TO_NAME,
+} from "@/shared/config/constants/recipe";
 
 type UseSearchResultsProps = {
   q: string;
@@ -55,12 +59,15 @@ export const useSearchResults = ({
     tagCodes,
     q,
   ]);
+  const dishType = dishTypeCode
+    ? DISH_TYPE_CODES_TO_NAME[dishTypeCode as keyof typeof DISH_TYPE_CODES]
+    : "전체";
 
   const noResults = recipes.length === 0 && !isFetching;
   const noResultsMessage =
     q && recipes.length === 0
       ? `"${q}"에 해당하는 레시피가 없습니다.`
-      : `"${dishTypeCode}"에 해당하는 레시피가 없습니다.`;
+      : `"${dishType}"에 해당하는 레시피가 없습니다.`;
 
   return {
     recipes,

--- a/src/widgets/SearchClient/index.tsx
+++ b/src/widgets/SearchClient/index.tsx
@@ -17,7 +17,6 @@ type SearchClientProps = {
 };
 
 export const SearchClient = ({ initialRecipes }: SearchClientProps) => {
-  // 1. 검색 상태 관리 (URL 파라미터 기반)
   const {
     q,
     sort,
@@ -34,7 +33,6 @@ export const SearchClient = ({ initialRecipes }: SearchClientProps) => {
     updateTags,
   } = useSearchState();
 
-  // 2. 검색 결과 관리 (무한 스크롤)
   const {
     recipes,
     hasNextPage,
@@ -51,7 +49,6 @@ export const SearchClient = ({ initialRecipes }: SearchClientProps) => {
     initialRecipes,
   });
 
-  // 3. 드로어 상태 관리
   const { isDrawerOpen, setIsDrawerOpen, drawerConfig, openDrawer } =
     useSearchDrawer({
       dishType,
@@ -64,7 +61,6 @@ export const SearchClient = ({ initialRecipes }: SearchClientProps) => {
 
   return (
     <div className="flex flex-col bg-[#ffffff]">
-      {/* 검색 필터 UI */}
       <SearchFilters
         inputValue={inputValue}
         handleInputChange={handleInputChange}
@@ -77,7 +73,6 @@ export const SearchClient = ({ initialRecipes }: SearchClientProps) => {
         onTagsClick={() => openDrawer("tags")}
       />
 
-      {/* 검색 결과 그리드 */}
       <RecipeGrid
         recipes={recipes}
         hasNextPage={hasNextPage}
@@ -89,7 +84,6 @@ export const SearchClient = ({ initialRecipes }: SearchClientProps) => {
         height={72}
       />
 
-      {/* 필터 선택 드로어 */}
       <CategoryDrawer
         open={isDrawerOpen}
         onOpenChange={setIsDrawerOpen}


### PR DESCRIPTION
- `CategoryDetailPage`에서 `useParams`의 파라미터를 `id`로 변경하여 URL 구조에 맞게 수정하였습니다.
- `SearchPage`에서 서버 컴포넌트의 주석을 제거하고, 클라이언트 컴포넌트에 데이터 전달 방식을 명확히 하였습니다.
- `UserInfoEditButton`의 클릭 이벤트 경로를 `/users/edit`로 수정하여 사용자 정보 수정 페이지로의 이동을 개선하였습니다.
- 레시피 관련 상수에 `DISH_TYPE_CODES_TO_NAME`를 추가하여 코드의 가독성을 높였습니다.
- 검색 필터에서 태그에 이모지를 추가하여 사용자 경험을 향상시켰습니다.