### PR TITLE
feat: comprehensive "Auth Contract" specification and regression lock for authentication behavior

### DIFF
--- a/docs/auth-contract.md
+++ b/docs/auth-contract.md
@@ -23,31 +23,56 @@ Auth logic is spread across `apiClient`, `auth.ts`, `handle401Error`, `useAuthMa
 
 ## Endpoint Kinds
 
-| Kind | Example | 쿠키 없을 때 서버 응답 (가정) | silentOn401 |
-|---|---|---|---|
-| public | /auth/login, /health | 200 (쿠키 안 봄) | N/A (401 안 남) |
-| optional-auth | /v2/recipes/{id}/status | 401 (또는 200 w/ 공개 필드 only; 클라이언트는 401 케이스도 견뎌야 함) | **true** |
-| required | /v2/users/me | 401 | false (기본) |
+| Kind | Example | 쿠키 없을 때 서버 응답 (가정) |
+|---|---|---|
+| public | /auth/login, /health | 200 (쿠키 안 봄) |
+| optional-auth | /v2/recipes/{id}/status | 401 (또는 200 w/ 공개 필드 only; 클라이언트는 401 케이스도 견뎌야 함) |
+| required | /v2/users/me | 401 |
+
+클라이언트는 **라우트 종류로 분기하지 않는다.** 이전 설계는 per-request `silentOn401` 옵션으로 optional-auth 엔드포인트만 silent 처리했지만, 이는 (1) BOTH_EXPIRED 사용자가 optional-auth 호출 시 잘못 silent되고 (2) ANONYMOUS 사용자가 required 호출 시 거짓 토스트가 뜨는 문제가 있었음. 현재 설계는 **서버의 refresh response body 시그널**만으로 분기 — 다음 섹션 참조.
+
+## Refresh Response Discrimination
+
+`/api/auth/refresh` Next route (src/app/api/auth/refresh/route.ts)는 쿠키 상태를 자체 판정해 세 종류 응답을 내려준다:
+
+| 응답 | 조건 | 시그널 (body.error) |
+|---|---|---|
+| 200 + Set-Cookie | refresh 성공 | (본문 데이터) |
+| 401 | **쿠키 없음** (route.ts:37-47에서 차단) | `"No refresh token available"` |
+| 401 | 쿠키 있지만 백엔드 만료 (route.ts:84-87) | `"Token refresh failed"` |
+
+클라이언트 `performTokenRefresh`(src/shared/api/auth.ts)는 이 body를 읽어 `RefreshResult`로 분기:
+
+- `success` — response.ok
+- `no_session` — 401 + `body.error === "No refresh token available"` → **forceLogout 스킵 (silent)**
+- `expired` — 401 + 다른 body → forceLogout 발행
+- `network_error` — fetch reject → forceLogout 발행
+
+`refreshToken()` 외부 반환은 boolean(성공/실패) 유지 — `handle401Error` 경로에서 retry 여부만 판정.
+
+**httpOnly 쿠키라 클라이언트 단독으로는 "쿠키 유무"를 알 수 없다.** 서버(Next route)만 확신 가능. 그래서 client-state(Zustand `isAuthenticated`, localStorage 플래그 등)로 판정하는 대신 **서버 응답에 의존**한다. 과거 `16e3348`/`958d6af` 사이클에서 client-state 기반 gate가 drift로 깨졌던 경험의 교훈.
 
 ## Contract Matrix (State × Endpoint)
 
-각 셀은 `apiClient(endpoint, options)` 호출의 post-condition을 정의:
+각 셀은 `apiClient(endpoint)` 호출의 post-condition을 정의:
 - **forceLogout**: `forceLogout` 커스텀 이벤트 발행 여부 (= "로그인 만료" 토스트 표시)
 - **refreshCalls**: `/api/auth/refresh` 호출 횟수
 - **retry**: 원요청 재시도 여부
 - **result**: apiClient가 반환하는 값 또는 throw하는 에러
 
-| State | public | optional-auth (silentOn401=true) | required (silentOn401=false) |
+라우트는 토스트 여부를 결정하지 않는다 — "라우트 무관 anonymous silent" 정책. 분기는 refresh response body 시그널로 이루어짐 (상단 섹션 참조).
+
+| State | public | optional-auth | required |
 |---|---|---|---|
-| ANONYMOUS | forceLogout=NO, refresh=0, retry=NO, result=data | forceLogout=**NO**, refresh=1 (401), retry=NO, result=throw ApiError(401) | forceLogout=**YES**, refresh=1 (401), retry=NO, result=throw ApiError(401) |
+| ANONYMOUS | forceLogout=NO, refresh=0, retry=NO, result=data | forceLogout=**NO**, refresh=1 (401 + no_session), retry=NO, result=throw ApiError(401) | forceLogout=**NO**, refresh=1 (401 + no_session), retry=NO, result=throw ApiError(401) |
 | VALID | forceLogout=NO, refresh=0, retry=NO, result=data | forceLogout=NO, refresh=0, retry=NO, result=data | forceLogout=NO, refresh=0, retry=NO, result=data |
-| ACCESS_EXPIRED | forceLogout=NO, refresh=0, retry=NO, result=data (public은 쿠키 무관) | forceLogout=NO, refresh=1 (200), retry=YES, result=data | forceLogout=NO, refresh=1 (200), retry=YES, result=data |
-| BOTH_EXPIRED | forceLogout=NO, refresh=0, retry=NO, result=data | forceLogout=**NO**, refresh=1 (401), retry=NO, result=throw ApiError(401) | forceLogout=**YES**, refresh=1 (401), retry=NO, result=throw ApiError(401) |
+| ACCESS_EXPIRED | forceLogout=NO, refresh=0, retry=NO, result=data | forceLogout=NO, refresh=1 (200), retry=YES, result=data | forceLogout=NO, refresh=1 (200), retry=YES, result=data |
+| BOTH_EXPIRED | forceLogout=NO, refresh=0, retry=NO, result=data | forceLogout=**YES**, refresh=1 (401 + expired), retry=NO, result=throw ApiError(401) | forceLogout=**YES**, refresh=1 (401 + expired), retry=NO, result=throw ApiError(401) |
 
 **핵심 행 (버그 재발 감시):**
-- ANONYMOUS × optional-auth → forceLogout **NO**. 이걸 YES로 바꾸는 코드 변경은 계약 위반.
-- BOTH_EXPIRED × optional-auth → forceLogout **NO**. 동일.
-- 반대로 required 엔드포인트의 anonymous/both-expired는 여전히 forceLogout=YES. 이건 의도된 현재 동작. **알려진 UX 한계**: "한 번도 로그인 안 한 사용자가 required 페이지에 진입하면 토스트"는 이 계약 위에서는 그대로. 개선하려면 이 행을 바꾸고 테스트도 같이 수정 필요.
+- **ANONYMOUS × required → forceLogout NO** (이게 이 계약 도입의 직접 동기. 한 번도 로그인 안 한 사용자는 required 페이지에 진입해도 "로그인 만료" 토스트 안 뜸).
+- **BOTH_EXPIRED × optional-auth → forceLogout YES** (진짜 만료된 사용자는 어떤 라우트든 토스트 뜸. 이전 silentOn401 설계에서 잘못 silent 처리되던 행).
+- ANONYMOUS × 모든 엔드포인트 → forceLogout NO는 **refresh response body의 "No refresh token available" 시그널**에 의존. Next route가 이 시그널을 바꾸면 전 행이 깨진다.
 
 ## Concurrency / Timing Contract
 
@@ -62,7 +87,7 @@ Auth logic is spread across `apiClient`, `auth.ts`, `handle401Error`, `useAuthMa
 | Scenario | Expected |
 |---|---|
 | E1: refresh 200 성공 → retry 요청이 401 (계정 정지/권한 변경) | apiClient는 ApiError(401) throw. **forceLogout은 발행하지 않음** (refresh 자체는 성공했음). |
-| E2: refresh 요청이 네트워크 에러 (reject) | refresh 실패로 간주. 나머지는 "refresh 401"과 동일 — silent이면 no toast, 아니면 toast. |
+| E2: refresh fetch가 네트워크 에러 (reject) | `RefreshResult = "network_error"` → expired와 동일 취급. forceLogout 발행. |
 
 ## State Mutations (Zustand)
 
@@ -82,16 +107,17 @@ Auth logic is spread across `apiClient`, `auth.ts`, `handle401Error`, `useAuthMa
 
 ### 주요 회귀 시나리오 → 실패하는 it
 
-| 코드 변경 | 실패하는 `it` (파일: auth-contract.test.ts 기준) |
+| 코드 변경 | 실패하는 `it` |
 |---|---|
-| `performTokenRefresh`의 catch에서 `dispatchForceLogoutEvent` 복원 | `ANONYMOUS × optional-auth > contract: forceLogout=false, ...`, `BOTH_EXPIRED × optional-auth > contract: forceLogout=false, ...`, `E2-silent: silent=true면 refresh network error에도 forceLogout 없음` |
-| `apiClient`가 `silentOn401`을 `handle401Error`에 전달 안 함 (destructure 누락 또는 인자 제거) | optional-auth 열 전체 4 row (`ANONYMOUS × optional-auth`, `VALID × optional-auth`, `ACCESS_EXPIRED × optional-auth`, `BOTH_EXPIRED × optional-auth`), `E2-silent: silent=true면 refresh network error에도 forceLogout 없음`, `getRecipeStatus는 익명 사용자에게 forceLogout을 발행하지 않는다`, `getRecipesStatus (배치)도 동일하게 익명에서 toast 없음` |
-| `getRecipeStatus`/`getRecipesStatus`에서 `silentOn401: true` 제거 | `getRecipeStatus는 익명 사용자에게 forceLogout을 발행하지 않는다`, `getRecipesStatus (배치)도 동일하게 익명에서 toast 없음` |
+| `performTokenRefresh`가 body 시그널 분기를 버리고 단순 boolean으로 되돌아감 | ANONYMOUS 행 전체 (`ANONYMOUS × public/optional-auth/required`), `Route-agnostic anonymous silence > 익명 사용자가 required 라우트...`, `Route-agnostic anonymous silence > 익명 사용자가 optional-auth 라우트...`, `getRecipeStatus는 익명 사용자에게 forceLogout을 발행하지 않는다`, `getRecipesStatus (배치)도 동일하게 익명에서 toast 없음` |
+| `NO_SESSION_ERROR_MESSAGE` 문자열을 Next route 응답과 다르게 바꿈 | 위와 동일 (시그널 매칭 실패 → expired 경로로 빠짐) |
+| `refreshToken`이 `no_session` 결과에서 `dispatchForceLogoutEvent`를 호출하도록 되돌림 | 위와 동일 |
+| `refreshToken`이 `expired`/`network_error`에서 dispatch를 스킵하도록 변경 | `BOTH_EXPIRED × optional-auth/required`, `Route-agnostic anonymous silence > 진짜 만료 사용자는 어떤 라우트든 forceLogout 발행`, `E2: refresh fetch가 네트워크 에러면 forceLogout을 발행한다` |
 | `refreshToken`의 cooldown 분기 제거 | `C2: cooldown 내 재시도 → refresh 호출되지 않고 forceLogout 재발행 없음` |
 | `refreshToken`의 dedup (refreshPromise 공유) 제거 | `C1: 두 요청이 동시에 401 → refresh는 1번만 호출된다 (dedup)` |
-| `refreshToken`이 cooldown 만료를 인식 못 함 (`lastRefreshFailTime` 리셋 로직 오류 등) | `C3: cooldown 만료 후 재시도 → refresh 다시 호출된다` |
+| `refreshToken`이 cooldown 만료를 인식 못 함 | `C3: cooldown 만료 후 재시도 → refresh 다시 호출된다` |
 | `handle401Error`가 refresh 성공 후 retry 에러에서 null 반환 안 함 | `E1: refresh 200 성공 후 retry가 401이면 ApiError 반환하지만 forceLogout은 없다` |
-| `performTokenRefresh`가 throw로 복귀 (pure boolean 반환을 깨뜨림) | cooldown 경로가 불안정해져 C2/C3/매트릭스 동시 영향. 대표적으로 `ACCESS_EXPIRED × optional-auth/required`의 retry=true 가정이 깨짐 |
+| Next `/api/auth/refresh` route에서 쿠키 없음 판정(line 37-47) 제거 | 백엔드로 요청이 흘러가서 의도치 않은 응답이 올 수 있음 — 하네스가 가정하는 body가 맞지 않게 되어 ANONYMOUS 행 전체 및 route-agnostic 테스트 실패 가능 |
 
 ### 매트릭스에 row 추가 시 업데이트해야 할 곳
 

--- a/docs/auth-contract.md
+++ b/docs/auth-contract.md
@@ -74,18 +74,33 @@ Auth logic is spread across `apiClient`, `auth.ts`, `handle401Error`, `useAuthMa
 
 ## Regression Lock (이 파일 바꾸면 어느 테스트가 깨진다)
 
-코드 변경이 이 계약을 위반하면 `auth-contract.test.ts`가 빨간불로 변한다. 주요 매핑:
+`src/shared/api/__tests__/auth-contract.test.ts` 기준. 코드 변경이 계약을 위반하면 나열된 `it`가 실패한다.
 
-| 코드 변경 | 깨지는 행 |
+### 전체 매트릭스 (`Auth Contract: State × Endpoint matrix`)
+
+12 rows. 각 row가 `"$state × $endpoint > contract: forceLogout=..., refresh=..., retry=..., result=..."` 이름으로 실행됨. 매트릭스의 어떤 셀이 깨지든 이 describe 블록에서 노출된다. 추가로 `"명세 문서와 row 개수가 일치한다 (명세 누락 방지)"` 테스트가 row 개수가 12에서 벗어나면 즉시 실패한다.
+
+### 주요 회귀 시나리오 → 실패하는 it
+
+| 코드 변경 | 실패하는 `it` (파일: auth-contract.test.ts 기준) |
 |---|---|
-| `performTokenRefresh`의 catch에서 `dispatchForceLogoutEvent` 호출 복원 | ANONYMOUS × optional-auth, BOTH_EXPIRED × optional-auth (2 row + edge E2) |
-| `apiClient`가 `silentOn401`을 `handle401Error`에 전달하지 않음 | optional-auth 열 전체 (4 row) |
-| `getRecipeStatus`에서 `silentOn401: true` 제거 | getRecipeStatus end-to-end 전용 테스트 |
-| `refreshToken`의 cooldown 분기 제거 | C2 |
-| `refreshToken`의 dedup(refreshPromise 공유) 제거 | C1 |
-| `useUserStore.logoutAction`에서 `user=null` 제거 | Zustand 단위 테스트 (별도) |
+| `performTokenRefresh`의 catch에서 `dispatchForceLogoutEvent` 복원 | `ANONYMOUS × optional-auth > contract: forceLogout=false, ...`, `BOTH_EXPIRED × optional-auth > contract: forceLogout=false, ...`, `E2-silent: silent=true면 refresh network error에도 forceLogout 없음` |
+| `apiClient`가 `silentOn401`을 `handle401Error`에 전달 안 함 (destructure 누락 또는 인자 제거) | optional-auth 열 전체 4 row (`ANONYMOUS × optional-auth`, `VALID × optional-auth`, `ACCESS_EXPIRED × optional-auth`, `BOTH_EXPIRED × optional-auth`), `E2-silent: silent=true면 refresh network error에도 forceLogout 없음`, `getRecipeStatus는 익명 사용자에게 forceLogout을 발행하지 않는다`, `getRecipesStatus (배치)도 동일하게 익명에서 toast 없음` |
+| `getRecipeStatus`/`getRecipesStatus`에서 `silentOn401: true` 제거 | `getRecipeStatus는 익명 사용자에게 forceLogout을 발행하지 않는다`, `getRecipesStatus (배치)도 동일하게 익명에서 toast 없음` |
+| `refreshToken`의 cooldown 분기 제거 | `C2: cooldown 내 재시도 → refresh 호출되지 않고 forceLogout 재발행 없음` |
+| `refreshToken`의 dedup (refreshPromise 공유) 제거 | `C1: 두 요청이 동시에 401 → refresh는 1번만 호출된다 (dedup)` |
+| `refreshToken`이 cooldown 만료를 인식 못 함 (`lastRefreshFailTime` 리셋 로직 오류 등) | `C3: cooldown 만료 후 재시도 → refresh 다시 호출된다` |
+| `handle401Error`가 refresh 성공 후 retry 에러에서 null 반환 안 함 | `E1: refresh 200 성공 후 retry가 401이면 ApiError 반환하지만 forceLogout은 없다` |
+| `performTokenRefresh`가 throw로 복귀 (pure boolean 반환을 깨뜨림) | cooldown 경로가 불안정해져 C2/C3/매트릭스 동시 영향. 대표적으로 `ACCESS_EXPIRED × optional-auth/required`의 retry=true 가정이 깨짐 |
 
-이 표는 Task 9에서 실제 it 이름으로 업데이트될 예정.
+### 매트릭스에 row 추가 시 업데이트해야 할 곳
+
+1. 이 문서의 Contract Matrix 표
+2. `src/shared/api/__tests__/auth-contract.test.ts`의 `CONTRACT` 배열
+3. `"명세 문서와 row 개수가 일치한다"` 테스트의 `toHaveLength(n)` 값
+4. 이 Regression Lock 표의 해당 시나리오 반영
+
+누락 시 `"명세 문서와 row 개수가 일치한다"` 단일 테스트가 곧바로 실패하여 drift를 막는다.
 
 ## Out of scope (이 계약이 다루지 않는 것)
 

--- a/docs/auth-contract.md
+++ b/docs/auth-contract.md
@@ -1,0 +1,96 @@
+# Auth Contract
+
+> This is the authoritative specification of authentication behavior in this project.
+> Any code change that violates a row in the tables below must update this document in the same PR.
+> Row violations are enforced by `src/shared/api/__tests__/auth-contract.test.ts`.
+
+## Why this exists
+
+Auth logic is spread across `apiClient`, `auth.ts`, `handle401Error`, `useAuthManager`, `AppStateInitializer`, `useUserStore`, and `/api/auth/refresh` route. A bug ("anonymous users see a 'session expired' toast on detail pages") has regressed multiple times because each piece is tested in isolation while the contract between them is not. This document defines the contract. The contract test locks it in.
+
+## Session States (equivalence classes)
+
+4 equivalence classes. "State" means (access cookie, refresh cookie, Zustand user) — but the cookies are httpOnly, so from the client's perspective, state is distinguishable only by how the server responds.
+
+| State | Meaning | How to simulate in tests |
+|---|---|---|
+| ANONYMOUS | 쿠키 없음 — fresh visitor or post-logout. ANONYMOUS_NEVER와 ANONYMOUS_LOGGED_OUT은 계약상 동일 클래스. | mockFetch: 원요청 401 → refresh 401 |
+| VALID | 쿠키 유효 — 정상 세션 | mockFetch: 원요청 200 |
+| ACCESS_EXPIRED | access만 만료, refresh 유효 | mockFetch: 원요청 401 → refresh 200 → retry 200 |
+| BOTH_EXPIRED | access + refresh 둘 다 만료 | mockFetch: 원요청 401 → refresh 401 |
+
+(BOOTSTRAPPING은 별도 관심사 — `AppStateInitializer`에서 `/me`를 호출하는 초기화 플로우. 이 계약은 정상 앱 런타임 중 요청 동작을 정의하며, 초기 부트스트랩은 별도 테스트 대상.)
+
+## Endpoint Kinds
+
+| Kind | Example | 쿠키 없을 때 서버 응답 (가정) | silentOn401 |
+|---|---|---|---|
+| public | /auth/login, /health | 200 (쿠키 안 봄) | N/A (401 안 남) |
+| optional-auth | /v2/recipes/{id}/status | 401 (또는 200 w/ 공개 필드 only; 클라이언트는 401 케이스도 견뎌야 함) | **true** |
+| required | /v2/users/me | 401 | false (기본) |
+
+## Contract Matrix (State × Endpoint)
+
+각 셀은 `apiClient(endpoint, options)` 호출의 post-condition을 정의:
+- **forceLogout**: `forceLogout` 커스텀 이벤트 발행 여부 (= "로그인 만료" 토스트 표시)
+- **refreshCalls**: `/api/auth/refresh` 호출 횟수
+- **retry**: 원요청 재시도 여부
+- **result**: apiClient가 반환하는 값 또는 throw하는 에러
+
+| State | public | optional-auth (silentOn401=true) | required (silentOn401=false) |
+|---|---|---|---|
+| ANONYMOUS | forceLogout=NO, refresh=0, retry=NO, result=data | forceLogout=**NO**, refresh=1 (401), retry=NO, result=throw ApiError(401) | forceLogout=**YES**, refresh=1 (401), retry=NO, result=throw ApiError(401) |
+| VALID | forceLogout=NO, refresh=0, retry=NO, result=data | forceLogout=NO, refresh=0, retry=NO, result=data | forceLogout=NO, refresh=0, retry=NO, result=data |
+| ACCESS_EXPIRED | forceLogout=NO, refresh=0, retry=NO, result=data (public은 쿠키 무관) | forceLogout=NO, refresh=1 (200), retry=YES, result=data | forceLogout=NO, refresh=1 (200), retry=YES, result=data |
+| BOTH_EXPIRED | forceLogout=NO, refresh=0, retry=NO, result=data | forceLogout=**NO**, refresh=1 (401), retry=NO, result=throw ApiError(401) | forceLogout=**YES**, refresh=1 (401), retry=NO, result=throw ApiError(401) |
+
+**핵심 행 (버그 재발 감시):**
+- ANONYMOUS × optional-auth → forceLogout **NO**. 이걸 YES로 바꾸는 코드 변경은 계약 위반.
+- BOTH_EXPIRED × optional-auth → forceLogout **NO**. 동일.
+- 반대로 required 엔드포인트의 anonymous/both-expired는 여전히 forceLogout=YES. 이건 의도된 현재 동작. **알려진 UX 한계**: "한 번도 로그인 안 한 사용자가 required 페이지에 진입하면 토스트"는 이 계약 위에서는 그대로. 개선하려면 이 행을 바꾸고 테스트도 같이 수정 필요.
+
+## Concurrency / Timing Contract
+
+| Scenario | Expected |
+|---|---|
+| C1: 두 요청이 거의 동시에 401 → 각자 handle401Error 진입 | `/api/auth/refresh`는 **1번만** 호출 (dedup). 두 요청 모두 refresh 결과에 따라 retry. |
+| C2: refresh 실패 직후 (5초 cooldown 내) 또 다른 401 요청 | refresh는 **호출 안 됨** (cooldown). forceLogout은 **재발행 안 됨** (이미 첫 실패 때 발행). |
+| C3: cooldown 만료 후 401 요청 | refresh 다시 호출됨. |
+
+## Edge Cases
+
+| Scenario | Expected |
+|---|---|
+| E1: refresh 200 성공 → retry 요청이 401 (계정 정지/권한 변경) | apiClient는 ApiError(401) throw. **forceLogout은 발행하지 않음** (refresh 자체는 성공했음). |
+| E2: refresh 요청이 네트워크 에러 (reject) | refresh 실패로 간주. 나머지는 "refresh 401"과 동일 — silent이면 no toast, 아니면 toast. |
+
+## State Mutations (Zustand)
+
+계약에서 Zustand `useUserStore` 변화는 **최소한**만 포함:
+- `performLogout` 성공 시: user=null, isAuthenticated=false (기존 `logoutAction`)
+- `forceLogout` 이벤트 수신 시: `useAuthManager`가 `logoutAction` 호출 → user=null
+
+이 외 시점(리프레시 성공 등)에는 store를 직접 건드리지 않는다. 유효 세션의 user는 `/me` 쿼리 결과로 hydration된 상태가 유지된다.
+
+## Regression Lock (이 파일 바꾸면 어느 테스트가 깨진다)
+
+코드 변경이 이 계약을 위반하면 `auth-contract.test.ts`가 빨간불로 변한다. 주요 매핑:
+
+| 코드 변경 | 깨지는 행 |
+|---|---|
+| `performTokenRefresh`의 catch에서 `dispatchForceLogoutEvent` 호출 복원 | ANONYMOUS × optional-auth, BOTH_EXPIRED × optional-auth (2 row + edge E2) |
+| `apiClient`가 `silentOn401`을 `handle401Error`에 전달하지 않음 | optional-auth 열 전체 (4 row) |
+| `getRecipeStatus`에서 `silentOn401: true` 제거 | getRecipeStatus end-to-end 전용 테스트 |
+| `refreshToken`의 cooldown 분기 제거 | C2 |
+| `refreshToken`의 dedup(refreshPromise 공유) 제거 | C1 |
+| `useUserStore.logoutAction`에서 `user=null` 제거 | Zustand 단위 테스트 (별도) |
+
+이 표는 Task 9에서 실제 it 이름으로 업데이트될 예정.
+
+## Out of scope (이 계약이 다루지 않는 것)
+
+- `AppStateInitializer` 초기 부트스트랩 (앱 로드 시 `/me` 호출 순서). 별도 테스트.
+- OAuth 콜백 라우트 (`/api/auth/callback/*`).
+- WebSocket 인증 (`/ws/*`).
+- CSRF 토큰.
+- 다중 탭 동기화.

--- a/src/app/landing/page.tsx
+++ b/src/app/landing/page.tsx
@@ -1,20 +1,45 @@
 "use client";
 
 import {
+  createLandingFAQStructuredData,
+  createTagItemListStructuredData,
+} from "@/shared/lib/metadata/structuredData";
+
+import {
   FeatureShowcase,
   FinalCTA,
   HeroSection,
   ProblemCards,
   StatsSection,
+  TagChipsSection,
   TestimonialCarousel,
 } from "@/features/landing";
+import { LANDING_TAG_GROUPS } from "@/features/landing/config/landingTags";
 
 const LandingPage = () => {
+  const faqJsonLd = createLandingFAQStructuredData();
+  const tagItemListJsonLd = createTagItemListStructuredData(
+    LANDING_TAG_GROUPS.flatMap((group) => group.chips)
+  );
+
   return (
     <div className="flex flex-col bg-white">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(faqJsonLd).replace(/</g, "\\u003c"),
+        }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(tagItemListJsonLd).replace(/</g, "\\u003c"),
+        }}
+      />
       <HeroSection />
       <ProblemCards />
       <StatsSection />
+      <TagChipsSection />
       <FeatureShowcase />
       <TestimonialCarousel />
       <FinalCTA />

--- a/src/app/providers/PostHogPageView.tsx
+++ b/src/app/providers/PostHogPageView.tsx
@@ -5,20 +5,22 @@ import { usePathname, useSearchParams } from "next/navigation";
 
 import { usePostHog } from "posthog-js/react";
 
+import { shouldCapturePageview } from "./posthogPageviewGuard";
+
 const PostHogPageViewInner = () => {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const posthog = usePostHog();
 
   useEffect(() => {
-    if (pathname && posthog) {
-      let url = window.origin + pathname;
-      const search = searchParams.toString();
-      if (search) {
-        url = url + "?" + search;
-      }
-      posthog.capture("$pageview", { $current_url: url });
-    }
+    if (!pathname || !posthog) return;
+
+    const search = searchParams.toString();
+    const url = window.origin + pathname + (search ? `?${search}` : "");
+
+    if (!shouldCapturePageview(url)) return;
+
+    posthog.capture("$pageview", { $current_url: url });
   }, [pathname, searchParams, posthog]);
 
   return null;

--- a/src/app/providers/PostHogProvider.tsx
+++ b/src/app/providers/PostHogProvider.tsx
@@ -29,9 +29,6 @@ export const PostHogProvider = ({ children }: { children: ReactNode }) => {
           disable_session_recording: true,
           autocapture: false,
           capture_dead_clicks: false,
-          loaded: (ph) => {
-            ph.capture("$pageview", { $current_url: window.location.href });
-          },
         });
         isPostHogInitialized = true;
       };

--- a/src/app/providers/__tests__/posthogPageviewGuard.test.ts
+++ b/src/app/providers/__tests__/posthogPageviewGuard.test.ts
@@ -1,0 +1,48 @@
+import {
+  __resetPageviewGuard,
+  shouldCapturePageview,
+} from "../posthogPageviewGuard";
+
+describe("shouldCapturePageview", () => {
+  beforeEach(() => {
+    __resetPageviewGuard();
+  });
+
+  it("최초 호출은 true 를 반환한다", () => {
+    expect(shouldCapturePageview("https://www.recipio.kr/")).toBe(true);
+  });
+
+  it("같은 URL 로 다시 호출하면 false 를 반환한다", () => {
+    const url = "https://www.recipio.kr/recipes/abc";
+    shouldCapturePageview(url);
+    expect(shouldCapturePageview(url)).toBe(false);
+  });
+
+  it("URL 이 바뀌면 다시 true 를 반환한다", () => {
+    shouldCapturePageview("https://www.recipio.kr/recipes/abc");
+    expect(shouldCapturePageview("https://www.recipio.kr/recipes/def")).toBe(
+      true
+    );
+  });
+
+  it("쿼리 문자열만 다르면 새 URL 로 간주해 true 를 반환한다", () => {
+    shouldCapturePageview("https://www.recipio.kr/search?q=a");
+    expect(shouldCapturePageview("https://www.recipio.kr/search?q=b")).toBe(
+      true
+    );
+  });
+
+  it("동일 URL 을 3회 연속 호출하면 첫 호출만 true 다", () => {
+    const url = "https://www.recipio.kr/";
+    expect(shouldCapturePageview(url)).toBe(true);
+    expect(shouldCapturePageview(url)).toBe(false);
+    expect(shouldCapturePageview(url)).toBe(false);
+  });
+
+  it("__resetPageviewGuard 는 내부 상태를 초기화한다", () => {
+    const url = "https://www.recipio.kr/";
+    shouldCapturePageview(url);
+    __resetPageviewGuard();
+    expect(shouldCapturePageview(url)).toBe(true);
+  });
+});

--- a/src/app/providers/posthogPageviewGuard.ts
+++ b/src/app/providers/posthogPageviewGuard.ts
@@ -1,0 +1,11 @@
+let lastCapturedUrl: string | null = null;
+
+export const shouldCapturePageview = (url: string): boolean => {
+  if (lastCapturedUrl === url) return false;
+  lastCapturedUrl = url;
+  return true;
+};
+
+export const __resetPageviewGuard = (): void => {
+  lastCapturedUrl = null;
+};

--- a/src/entities/recipe/lib/metadata/__tests__/landingSchema.test.ts
+++ b/src/entities/recipe/lib/metadata/__tests__/landingSchema.test.ts
@@ -1,0 +1,58 @@
+/**
+ * @jest-environment node
+ */
+import {
+  createLandingFAQStructuredData,
+  createTagItemListStructuredData,
+} from "../schema";
+
+describe("createLandingFAQStructuredData", () => {
+  it("returns FAQPage with 6 questions", () => {
+    const json = createLandingFAQStructuredData();
+
+    expect(json["@context"]).toBe("https://schema.org");
+    expect(json["@type"]).toBe("FAQPage");
+    expect(json.mainEntity).toHaveLength(6);
+  });
+
+  it("every entry is a Question with acceptedAnswer", () => {
+    const json = createLandingFAQStructuredData();
+
+    for (const entry of json.mainEntity) {
+      expect(entry["@type"]).toBe("Question");
+      expect(entry.name).toBeTruthy();
+      expect(entry.acceptedAnswer["@type"]).toBe("Answer");
+      expect(entry.acceptedAnswer.text).toBeTruthy();
+    }
+  });
+
+  it("covers YouTube extraction as one of the questions", () => {
+    const json = createLandingFAQStructuredData();
+    const names = json.mainEntity.map((q) => q.name);
+    expect(names.some((n) => n.includes("YouTube"))).toBe(true);
+  });
+});
+
+describe("createTagItemListStructuredData", () => {
+  it("returns ItemList with one entry per input tag", () => {
+    const json = createTagItemListStructuredData([
+      { code: "HOME_PARTY", name: "홈파티" },
+      { code: "SOLO", name: "혼밥" },
+    ]);
+
+    expect(json["@type"]).toBe("ItemList");
+    expect(json.itemListElement).toHaveLength(2);
+  });
+
+  it("builds absolute URLs with SITE_URL prefix and encoded tag code", () => {
+    const json = createTagItemListStructuredData([
+      { code: "HOME_PARTY", name: "홈파티" },
+    ]);
+    const item = json.itemListElement[0];
+    expect(item["@type"]).toBe("ListItem");
+    expect(item.position).toBe(1);
+    expect(item.name).toBe("홈파티");
+    expect(item.url).toMatch(/\/search\/results\?tags=HOME_PARTY$/);
+    expect(item.url.startsWith("https://")).toBe(true);
+  });
+});

--- a/src/entities/recipe/lib/metadata/schema.ts
+++ b/src/entities/recipe/lib/metadata/schema.ts
@@ -157,6 +157,93 @@ export const createRecipeStructuredData = (
   };
 };
 
+// ────────────────────────────────────────────
+// Landing page structured data
+// ────────────────────────────────────────────
+
+type LandingFAQEntry = {
+  "@type": "Question";
+  name: string;
+  acceptedAnswer: {
+    "@type": "Answer";
+    text: string;
+  };
+};
+
+export const createLandingFAQStructuredData = () => {
+  const mainEntity: LandingFAQEntry[] = [
+    {
+      "@type": "Question",
+      name: "레시피오는 어떤 서비스인가요?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "레시피오는 30,000개 이상의 홈쿡 레시피를 제공하는 서비스입니다. YouTube 링크를 붙여넣기만 하면 레시피로 자동 추출되고, AI가 상황과 재료에 맞게 레시피를 추천해줍니다.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "YouTube 링크로 어떻게 레시피를 만드나요?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "'/recipes/new/youtube' 페이지에서 YouTube 영상 링크를 붙여넣으면 재료·조리순서·분량이 자동으로 추출되어 레시피로 저장됩니다.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "무료로 이용할 수 있나요?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "네. 레시피 탐색, YouTube 추출, AI 추천, 냉장고 재료 기반 추천까지 모든 핵심 기능을 무료로 사용할 수 있습니다.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "냉장고 재료로 레시피를 찾을 수 있나요?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "네. '/recipes/my-fridge'에서 보유한 재료를 등록하면 AI가 그 재료로 만들 수 있는 레시피를 자동으로 추천해줍니다.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "어떤 상황별 레시피가 있나요?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "홈파티, 기념일, 집들이, 브런치, 혼밥, 도시락, 다이어트, 야식, 술안주, 해장, 캠핑, 아이 반찬 등 상황별 태그로 레시피를 찾을 수 있습니다.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "AI 레시피 생성은 어떻게 작동하나요?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "가성비, 특정 영양성분 조합, 파인다이닝, 냉장고 재료 기반 네 가지 모드로 원하는 조건의 레시피를 AI가 생성해줍니다.",
+      },
+    },
+  ];
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity,
+  } as const;
+};
+
+export const createTagItemListStructuredData = (
+  tags: Array<{ code: string; name: string }>
+) => ({
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  itemListElement: tags.map((tag, i) => ({
+    "@type": "ListItem" as const,
+    position: i + 1,
+    name: tag.name,
+    url: `${SEO_CONSTANTS.SITE_URL}/search/results?tags=${encodeURIComponent(
+      tag.code
+    )}`,
+  })),
+});
+
 const MAX_SEARCH_ITEMS = 10;
 
 export const createSearchResultsJsonLd = (

--- a/src/entities/recipe/model/api.ts
+++ b/src/entities/recipe/model/api.ts
@@ -105,22 +105,18 @@ export const editRecipe = async ({
 
 export const getRecipeStatus = async (id: string): Promise<RecipeStatus> => {
   // optional-auth endpoint: 쿠키 있으면 개인화(liked/saved), 없으면 공개 필드.
-  // silentOn401: true로 익명 호출이 "로그인 만료" 토스트를 띄우지 않게 한다.
-  // 계약: docs/auth-contract.md (ANONYMOUS × optional-auth)
-  const response = await api.get<RecipeStatus>(`/v2/recipes/${id}/status`, {
-    silentOn401: true,
-  });
+  // 익명 사용자는 refresh response body 시그널("No refresh token available")로
+  // 라우트 무관하게 forceLogout dispatch가 스킵된다. 계약: docs/auth-contract.md
+  const response = await api.get<RecipeStatus>(`/v2/recipes/${id}/status`);
   return response;
 };
 
 export const getRecipesStatus = async (
   recipeIds: string[]
 ): Promise<RecipesStatusResponse> => {
-  const response = await api.post<RecipesStatusResponse>(
-    `/v2/recipes/status`,
-    { recipeIds },
-    { silentOn401: true }
-  );
+  const response = await api.post<RecipesStatusResponse>(`/v2/recipes/status`, {
+    recipeIds,
+  });
   return response;
 };
 

--- a/src/entities/recipe/model/api.ts
+++ b/src/entities/recipe/model/api.ts
@@ -104,16 +104,23 @@ export const editRecipe = async ({
 };
 
 export const getRecipeStatus = async (id: string): Promise<RecipeStatus> => {
-  const response = await api.get<RecipeStatus>(`/v2/recipes/${id}/status`);
+  // optional-auth endpoint: 쿠키 있으면 개인화(liked/saved), 없으면 공개 필드.
+  // silentOn401: true로 익명 호출이 "로그인 만료" 토스트를 띄우지 않게 한다.
+  // 계약: docs/auth-contract.md (ANONYMOUS × optional-auth)
+  const response = await api.get<RecipeStatus>(`/v2/recipes/${id}/status`, {
+    silentOn401: true,
+  });
   return response;
 };
 
 export const getRecipesStatus = async (
   recipeIds: string[]
 ): Promise<RecipesStatusResponse> => {
-  const response = await api.post<RecipesStatusResponse>(`/v2/recipes/status`, {
-    recipeIds,
-  });
+  const response = await api.post<RecipesStatusResponse>(
+    `/v2/recipes/status`,
+    { recipeIds },
+    { silentOn401: true }
+  );
   return response;
 };
 

--- a/src/features/landing/config/landingTags.ts
+++ b/src/features/landing/config/landingTags.ts
@@ -1,0 +1,54 @@
+// src/features/landing/config/landingTags.ts
+
+export type LandingTagChip = {
+  code: string;
+  name: string;
+};
+
+export type LandingTagGroup = {
+  id: "occasion" | "situation" | "speed";
+  emoji: string;
+  label: string;
+  chips: LandingTagChip[];
+};
+
+export const LANDING_TAG_GROUPS: LandingTagGroup[] = [
+  {
+    id: "occasion",
+    emoji: "💝",
+    label: "기념일·특별한 날",
+    chips: [
+      { code: "HOME_PARTY", name: "홈파티" },
+      { code: "HOLIDAY", name: "기념일" },
+      { code: "BRUNCH", name: "브런치" },
+      { code: "PICNIC", name: "피크닉" },
+    ],
+  },
+  {
+    id: "situation",
+    emoji: "🍽",
+    label: "일상·상황별",
+    chips: [
+      { code: "SOLO", name: "혼밥" },
+      { code: "LUNCHBOX", name: "도시락" },
+      { code: "HEALTHY", name: "다이어트" },
+      { code: "LATE_NIGHT", name: "야식" },
+      { code: "DRINK", name: "술안주" },
+      { code: "HANGOVER", name: "해장" },
+      { code: "CAMPING", name: "캠핑" },
+      { code: "KIDS", name: "아이 반찬" },
+    ],
+  },
+  {
+    id: "speed",
+    emoji: "⏱",
+    label: "빠르게 만드는",
+    chips: [
+      { code: "QUICK", name: "초스피드" },
+      { code: "AIR_FRYER", name: "에어프라이어" },
+    ],
+  },
+];
+
+export const buildTagSearchUrl = (code: string): string =>
+  `/search/results?tags=${encodeURIComponent(code)}`;

--- a/src/features/landing/index.ts
+++ b/src/features/landing/index.ts
@@ -4,4 +4,5 @@ export { HeroSection } from "./ui/HeroSection";
 export { ProblemCards } from "./ui/ProblemCards";
 export { RecipeCarousel } from "./ui/RecipeCarousel";
 export { StatsSection } from "./ui/StatsSection";
+export { TagChipsSection } from "./ui/TagChipsSection";
 export { TestimonialCarousel } from "./ui/TestimonialCarousel";

--- a/src/features/landing/ui/FeatureShowcase.tsx
+++ b/src/features/landing/ui/FeatureShowcase.tsx
@@ -12,12 +12,29 @@ type Feature = {
 
 const FEATURES: Feature[] = [
   {
-    badge: "유명 최신 레시피",
-    badgeColor: "bg-blue-50 text-blue-600",
-    title: "20,000개 이상의 검증된 레시피",
+    badge: "YouTube 추출",
+    badgeColor: "bg-red-50 text-red-600",
+    title: "YouTube 링크 하나로 레시피 완성",
     description:
-      "다양한 카테고리의 레시피와 유명 유튜버, 셰프들의 레시피 후기들을 만나보세요",
-    benefits: ["유명 최신 레시피", "유튜버, 셰프들의 레시피 후기"],
+      "영상을 멈추고 재료를 메모할 필요 없어요. 링크만 붙여넣으면 재료·조리순서·분량까지 자동 추출됩니다.",
+    benefits: [
+      "재료 자동 정리",
+      "조리 순서 단계별 정리",
+      "영상과 함께 보관",
+      "좋아하는 유튜버 레시피 그대로",
+    ],
+  },
+  {
+    badge: "30,000+ 레시피",
+    badgeColor: "bg-blue-50 text-blue-600",
+    title: "국내 최대 규모의 큐레이션 레시피",
+    description:
+      "YouTube 기반 레시피부터 AI 생성, 유명 홈쿡 레시피까지 30,000개 이상을 한 곳에서 탐색할 수 있어요.",
+    benefits: [
+      "유명 최신 레시피",
+      "YouTube 기반 레시피 다수 보유",
+      "상황별·기념일별 태그 분류",
+    ],
   },
   {
     badge: "AI 추천",
@@ -67,7 +84,7 @@ export const FeatureShowcase = () => {
           </p>
         </motion.div>
 
-        <div className="space-y-32">
+        <div className="space-y-24">
           {FEATURES.map((feature, index) => {
             const isReversed = index % 2 === 1;
 

--- a/src/features/landing/ui/FinalCTA.tsx
+++ b/src/features/landing/ui/FinalCTA.tsx
@@ -39,7 +39,7 @@ export const FinalCTA = () => {
             </h2>
 
             <p className="mx-auto max-w-3xl text-xl leading-relaxed text-gray-600 md:text-2xl">
-              20,000개 이상의 레시피와 AI 추천, 스마트 재료 관리까지
+              30,000+ 레시피와 AI 추천, YouTube 링크 추출까지
               <br className="hidden sm:block" />
               지금 바로 무료로 시작해보세요
             </p>

--- a/src/features/landing/ui/HeroSection.tsx
+++ b/src/features/landing/ui/HeroSection.tsx
@@ -32,7 +32,7 @@ export const HeroSection = () => {
           transition={{ duration: 0.8, delay: 0.1 }}
           className="border-olive-light/30 bg-olive-light/10 font-bold text-olive-medium mb-6 inline-block rounded-full border px-6 py-2 text-sm  backdrop-blur-sm"
         >
-          🍳 20,000+ 레시피 · AI 추천 · 스마트 재료 관리
+          🍳 30,000+ 레시피 · YouTube 링크 추출 · AI 맞춤 추천
         </motion.div>
 
         <motion.h1
@@ -58,11 +58,11 @@ export const HeroSection = () => {
           className="mb-12 max-w-3xl text-xl leading-relaxed text-gray-600 md:text-2xl"
         >
           <span className="text-olive-medium font-semibold">
-            만개 이상의 검증된 레시피
+            YouTube 링크 하나로 레시피를 저장
           </span>
-          에서 AI가 찾아주는
+          하고,
           <br className="hidden sm:block" />
-          나만의 맞춤 레시피를 경험하세요
+          30,000+ 레시피에서 AI가 맞춤 추천해드려요
         </motion.p>
 
         <motion.div

--- a/src/features/landing/ui/StatsSection.tsx
+++ b/src/features/landing/ui/StatsSection.tsx
@@ -18,9 +18,9 @@ type StatCard = {
 const STATS: StatCard[] = [
   {
     image: `${ICON_BASE_URL}book.webp`,
-    metric: "20,000+",
-    label: "검증된 셰프 레시피",
-    description: "매주 업데이트되는 큐레이션",
+    metric: "30,000+",
+    label: "큐레이션 레시피",
+    description: "YouTube · 유명 레시피 · AI 생성까지",
     accent: "from-purple-500/10 to-pink-500/10",
   },
   {

--- a/src/features/landing/ui/TagChipsSection.tsx
+++ b/src/features/landing/ui/TagChipsSection.tsx
@@ -1,0 +1,83 @@
+// src/features/landing/ui/TagChipsSection.tsx
+"use client";
+
+import Link from "next/link";
+
+import { motion } from "motion/react";
+
+import {
+  buildTagSearchUrl,
+  LANDING_TAG_GROUPS,
+} from "@/features/landing/config/landingTags";
+
+const CHIP_STAGGER_DELAY = 0.03;
+
+export const TagChipsSection = () => {
+  return (
+    <section className="relative w-full overflow-hidden bg-white px-4 py-12 md:py-20">
+      <div className="bg-olive-mint/5 absolute top-1/3 right-0 h-80 w-80 rounded-full blur-3xl" />
+
+      <div className="relative mx-auto max-w-7xl">
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.6 }}
+          className="mb-12 text-center"
+        >
+          <div className="bg-olive-light/10 text-olive-medium mb-4 inline-block rounded-full px-4 py-1 text-sm font-semibold">
+            상황별 레시피
+          </div>
+          <h2 className="text-dark mb-4 text-4xl font-extrabold md:text-5xl">
+            이런 날에도, 이런 상황에도
+          </h2>
+          <p className="mx-auto max-w-2xl text-lg text-gray-600">
+            원하는 상황에 딱 맞는 레시피를 바로 찾아보세요
+          </p>
+        </motion.div>
+
+        <div className="space-y-8">
+          {LANDING_TAG_GROUPS.map((group) => (
+            <motion.div
+              key={group.id}
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true, margin: "-50px" }}
+              transition={{ duration: 0.5 }}
+              className="flex flex-col gap-4 md:flex-row md:items-center md:gap-6"
+            >
+              <div className="flex items-center gap-2 md:w-52 md:shrink-0">
+                <span className="text-2xl">{group.emoji}</span>
+                <span className="text-dark text-base font-bold md:text-lg">
+                  {group.label}
+                </span>
+              </div>
+
+              <div className="flex flex-wrap gap-2 md:gap-3">
+                {group.chips.map((chip, index) => (
+                  <motion.div
+                    key={chip.code}
+                    initial={{ opacity: 0, scale: 0.9 }}
+                    whileInView={{ opacity: 1, scale: 1 }}
+                    viewport={{ once: true }}
+                    transition={{
+                      duration: 0.3,
+                      delay: index * CHIP_STAGGER_DELAY,
+                    }}
+                  >
+                    <Link
+                      href={buildTagSearchUrl(chip.code)}
+                      className="hover:border-olive-light hover:bg-olive-light/10 hover:text-olive-medium inline-flex items-center rounded-full border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm transition-all active:scale-[0.97] md:text-base"
+                    >
+                      # {chip.name}
+                    </Link>
+                  </motion.div>
+                ))}
+              </div>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/src/shared/api/__tests__/_auth-harness.ts
+++ b/src/shared/api/__tests__/_auth-harness.ts
@@ -1,0 +1,173 @@
+/**
+ * Auth contract 테스트용 하네스. jsdom 환경에서 fetch mock 시퀀스를 기반으로
+ * 세션 상태 × 엔드포인트 종류의 시나리오를 펼치고, post-condition을 검증한다.
+ * 계약 정의: docs/auth-contract.md
+ */
+
+export type SessionState = "ANONYMOUS" | "VALID" | "ACCESS_EXPIRED" | "BOTH_EXPIRED";
+export type EndpointKind = "public" | "optional-auth" | "required";
+
+// jsdom에 Response가 없을 수 있으므로 polyfill
+export const ensureResponsePolyfill = () => {
+  if (typeof (globalThis as any).Response !== "undefined") return;
+
+  class MockResponse {
+    ok: boolean;
+    status: number;
+    statusText: string;
+    _body: any;
+    _headers: Map<string, string>;
+
+    constructor(body: any, init?: { status?: number; statusText?: string }) {
+      this.status = init?.status ?? 200;
+      this.statusText = init?.statusText ?? "";
+      this.ok = this.status >= 200 && this.status < 300;
+      this._body = body;
+      this._headers = new Map([["content-type", "application/json"]]);
+    }
+
+    get headers() {
+      const headers = this._headers;
+      return {
+        get(key: string) {
+          return headers.get(key.toLowerCase()) ?? null;
+        },
+      };
+    }
+
+    async json() {
+      return typeof this._body === "string" ? JSON.parse(this._body) : this._body;
+    }
+
+    async text() {
+      return typeof this._body === "string" ? this._body : JSON.stringify(this._body);
+    }
+  }
+
+  (globalThis as any).Response = MockResponse;
+};
+
+const makeResponse = (body: any, status: number) =>
+  new (globalThis as any).Response(body, { status });
+
+export type Scenario = {
+  state: SessionState;
+  endpoint: EndpointKind;
+  /**
+   * optional-auth는 silentOn401=true로 호출, required는 false로 호출.
+   * public은 silentOn401 없음 — 어차피 401 안 남.
+   */
+  data?: any;
+};
+
+/**
+ * 시나리오를 mockFetch에 펼친다.
+ * - ANONYMOUS: 원요청 401 → refresh 401 (retry 없음)
+ * - VALID: 원요청 200
+ * - ACCESS_EXPIRED: 원요청 401 → refresh 200 → retry 200
+ * - BOTH_EXPIRED: 원요청 401 → refresh 401
+ * public 엔드포인트는 어떤 상태에서도 원요청 200 (쿠키 확인 안 함).
+ */
+export const arrangeScenario = (
+  mockFetch: jest.Mock,
+  scenario: Scenario
+): { expectedRefreshCalls: 0 | 1; expectedRetry: boolean } => {
+  const data = scenario.data ?? { ok: true };
+
+  if (scenario.endpoint === "public") {
+    mockFetch.mockReturnValueOnce(Promise.resolve(makeResponse(data, 200)));
+    return { expectedRefreshCalls: 0, expectedRetry: false };
+  }
+
+  switch (scenario.state) {
+    case "VALID":
+      mockFetch.mockReturnValueOnce(Promise.resolve(makeResponse(data, 200)));
+      return { expectedRefreshCalls: 0, expectedRetry: false };
+
+    case "ACCESS_EXPIRED":
+      mockFetch
+        .mockReturnValueOnce(Promise.resolve(makeResponse(null, 401))) // 원요청
+        .mockReturnValueOnce(Promise.resolve(makeResponse({}, 200)))    // refresh 성공
+        .mockReturnValueOnce(Promise.resolve(makeResponse(data, 200))); // retry 성공
+      return { expectedRefreshCalls: 1, expectedRetry: true };
+
+    case "ANONYMOUS":
+    case "BOTH_EXPIRED":
+      mockFetch
+        .mockReturnValueOnce(Promise.resolve(makeResponse(null, 401))) // 원요청
+        .mockReturnValueOnce(Promise.resolve(makeResponse(null, 401))); // refresh 실패
+      return { expectedRefreshCalls: 1, expectedRetry: false };
+  }
+};
+
+export type Outcome = {
+  forceLogoutEmitted: boolean;
+  refreshCalls: number;
+  retryCalled: boolean;
+  result: "data" | "apiError401" | "apiError_other";
+};
+
+/**
+ * 호출 결과와 fetch 호출 시퀀스를 바탕으로 Outcome을 계산한다.
+ */
+export const observeOutcome = (
+  mockFetch: jest.Mock,
+  forceLogoutHandler: jest.Mock,
+  apiResult: { success: true; data: any } | { success: false; error: any }
+): Outcome => {
+  const refreshCalls = mockFetch.mock.calls.filter(
+    ([url]) => typeof url === "string" && url.includes("/api/auth/refresh")
+  ).length;
+
+  // retry 판정: refresh 호출 이후에 non-refresh 호출이 또 있었는가
+  const refreshIdx = mockFetch.mock.calls.findIndex(
+    ([url]) => typeof url === "string" && url.includes("/api/auth/refresh")
+  );
+  const retryCalled =
+    refreshIdx >= 0 &&
+    mockFetch.mock.calls
+      .slice(refreshIdx + 1)
+      .some(([url]) => typeof url === "string" && !url.includes("/api/auth/refresh"));
+
+  let result: Outcome["result"];
+  if (apiResult.success) {
+    result = "data";
+  } else if (apiResult.error?.status === 401) {
+    result = "apiError401";
+  } else {
+    result = "apiError_other";
+  }
+
+  return {
+    forceLogoutEmitted: forceLogoutHandler.mock.calls.length > 0,
+    refreshCalls,
+    retryCalled,
+    result,
+  };
+};
+
+/**
+ * forceLogout 리스너 attach + detach 헬퍼.
+ */
+export const withForceLogoutHandler = () => {
+  const handler = jest.fn();
+  window.addEventListener("forceLogout", handler);
+  return {
+    handler,
+    detach: () => window.removeEventListener("forceLogout", handler),
+  };
+};
+
+/**
+ * 엔드포인트 종류별 URL과 옵션 매핑.
+ */
+export const endpointSpec = (kind: EndpointKind): { url: string; silentOn401: boolean } => {
+  switch (kind) {
+    case "public":
+      return { url: "/auth/login", silentOn401: false };
+    case "optional-auth":
+      return { url: "/v2/recipes/test-id/status", silentOn401: true };
+    case "required":
+      return { url: "/v2/users/me", silentOn401: false };
+  }
+};

--- a/src/shared/api/__tests__/_auth-harness.ts
+++ b/src/shared/api/__tests__/_auth-harness.ts
@@ -48,15 +48,20 @@ export const ensureResponsePolyfill = () => {
 };
 
 const makeResponse = (body: any, status: number) =>
-  new (globalThis as any).Response(body, { status });
+  new (globalThis as any).Response(
+    body !== null ? JSON.stringify(body) : null,
+    { status }
+  );
+
+// Next /api/auth/refresh route가 쿠키 없는 사용자에게 내려주는 body.error 값.
+// auth.ts의 NO_SESSION_ERROR_MESSAGE와 동일해야 한다.
+export const NO_SESSION_REFRESH_BODY = { error: "No refresh token available" };
+// 진짜 만료된 사용자가 받는 body (Next route가 line 84-87에서 생성).
+export const EXPIRED_REFRESH_BODY = { error: "Token refresh failed" };
 
 export type Scenario = {
   state: SessionState;
   endpoint: EndpointKind;
-  /**
-   * optional-auth는 silentOn401=true로 호출, required는 false로 호출.
-   * public은 silentOn401 없음 — 어차피 401 안 남.
-   */
   data?: any;
 };
 
@@ -92,10 +97,19 @@ export const arrangeScenario = (
       return { expectedRefreshCalls: 1, expectedRetry: true };
 
     case "ANONYMOUS":
+      mockFetch
+        .mockReturnValueOnce(Promise.resolve(makeResponse(null, 401))) // 원요청
+        .mockReturnValueOnce(
+          Promise.resolve(makeResponse(NO_SESSION_REFRESH_BODY, 401))
+        ); // refresh: 쿠키 없음 시그널
+      return { expectedRefreshCalls: 1, expectedRetry: false };
+
     case "BOTH_EXPIRED":
       mockFetch
         .mockReturnValueOnce(Promise.resolve(makeResponse(null, 401))) // 원요청
-        .mockReturnValueOnce(Promise.resolve(makeResponse(null, 401))); // refresh 실패
+        .mockReturnValueOnce(
+          Promise.resolve(makeResponse(EXPIRED_REFRESH_BODY, 401))
+        ); // refresh: 진짜 만료
       return { expectedRefreshCalls: 1, expectedRetry: false };
   }
 };
@@ -159,15 +173,15 @@ export const withForceLogoutHandler = () => {
 };
 
 /**
- * 엔드포인트 종류별 URL과 옵션 매핑.
+ * 엔드포인트 종류별 URL 매핑.
  */
-export const endpointSpec = (kind: EndpointKind): { url: string; silentOn401: boolean } => {
+export const endpointSpec = (kind: EndpointKind): { url: string } => {
   switch (kind) {
     case "public":
-      return { url: "/auth/login", silentOn401: false };
+      return { url: "/auth/login" };
     case "optional-auth":
-      return { url: "/v2/recipes/test-id/status", silentOn401: true };
+      return { url: "/v2/recipes/test-id/status" };
     case "required":
-      return { url: "/v2/users/me", silentOn401: false };
+      return { url: "/v2/users/me" };
   }
 };

--- a/src/shared/api/__tests__/auth-contract.test.ts
+++ b/src/shared/api/__tests__/auth-contract.test.ts
@@ -1,0 +1,318 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import {
+  arrangeScenario,
+  EndpointKind,
+  endpointSpec,
+  ensureResponsePolyfill,
+  observeOutcome,
+  SessionState,
+  withForceLogoutHandler,
+} from "./_auth-harness";
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+ensureResponsePolyfill();
+
+let apiClient: typeof import("../client").apiClient;
+
+beforeEach(() => {
+  jest.resetModules();
+  mockFetch.mockReset();
+  jest.useFakeTimers();
+  apiClient = require("../client").apiClient;
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+// ========================================================================
+// 계약 매트릭스 (docs/auth-contract.md 참조)
+// ========================================================================
+
+type ExpectedCell = {
+  forceLogout: boolean;
+  refreshCalls: 0 | 1;
+  retry: boolean;
+  result: "data" | "apiError401";
+};
+
+type ContractRow = {
+  state: SessionState;
+  endpoint: EndpointKind;
+  expected: ExpectedCell;
+};
+
+const CONTRACT: ContractRow[] = [
+  // ANONYMOUS row
+  {
+    state: "ANONYMOUS",
+    endpoint: "public",
+    expected: { forceLogout: false, refreshCalls: 0, retry: false, result: "data" },
+  },
+  {
+    state: "ANONYMOUS",
+    endpoint: "optional-auth",
+    expected: { forceLogout: false, refreshCalls: 1, retry: false, result: "apiError401" },
+  },
+  {
+    state: "ANONYMOUS",
+    endpoint: "required",
+    expected: { forceLogout: true, refreshCalls: 1, retry: false, result: "apiError401" },
+  },
+  // VALID row
+  {
+    state: "VALID",
+    endpoint: "public",
+    expected: { forceLogout: false, refreshCalls: 0, retry: false, result: "data" },
+  },
+  {
+    state: "VALID",
+    endpoint: "optional-auth",
+    expected: { forceLogout: false, refreshCalls: 0, retry: false, result: "data" },
+  },
+  {
+    state: "VALID",
+    endpoint: "required",
+    expected: { forceLogout: false, refreshCalls: 0, retry: false, result: "data" },
+  },
+  // ACCESS_EXPIRED row
+  {
+    state: "ACCESS_EXPIRED",
+    endpoint: "public",
+    expected: { forceLogout: false, refreshCalls: 0, retry: false, result: "data" },
+  },
+  {
+    state: "ACCESS_EXPIRED",
+    endpoint: "optional-auth",
+    expected: { forceLogout: false, refreshCalls: 1, retry: true, result: "data" },
+  },
+  {
+    state: "ACCESS_EXPIRED",
+    endpoint: "required",
+    expected: { forceLogout: false, refreshCalls: 1, retry: true, result: "data" },
+  },
+  // BOTH_EXPIRED row
+  {
+    state: "BOTH_EXPIRED",
+    endpoint: "public",
+    expected: { forceLogout: false, refreshCalls: 0, retry: false, result: "data" },
+  },
+  {
+    state: "BOTH_EXPIRED",
+    endpoint: "optional-auth",
+    expected: { forceLogout: false, refreshCalls: 1, retry: false, result: "apiError401" },
+  },
+  {
+    state: "BOTH_EXPIRED",
+    endpoint: "required",
+    expected: { forceLogout: true, refreshCalls: 1, retry: false, result: "apiError401" },
+  },
+];
+
+describe("Auth Contract: State × Endpoint matrix", () => {
+  it("명세 문서와 row 개수가 일치한다 (명세 누락 방지)", () => {
+    // 4 states × 3 endpoints
+    expect(CONTRACT).toHaveLength(12);
+  });
+
+  describe.each(CONTRACT)(
+    "$state × $endpoint",
+    ({ state, endpoint, expected }) => {
+      it(`contract: forceLogout=${expected.forceLogout}, refresh=${expected.refreshCalls}, retry=${expected.retry}, result=${expected.result}`, async () => {
+        const spec = endpointSpec(endpoint);
+        arrangeScenario(mockFetch, { state, endpoint });
+        const { handler, detach } = withForceLogoutHandler();
+
+        let apiResult: { success: true; data: any } | { success: false; error: any };
+        try {
+          const data = await apiClient(spec.url, {
+            silentOn401: spec.silentOn401,
+          });
+          apiResult = { success: true, data };
+        } catch (error) {
+          apiResult = { success: false, error };
+        }
+
+        const outcome = observeOutcome(mockFetch, handler, apiResult);
+        detach();
+
+        expect(outcome.forceLogoutEmitted).toBe(expected.forceLogout);
+        expect(outcome.refreshCalls).toBe(expected.refreshCalls);
+        expect(outcome.retryCalled).toBe(expected.retry);
+        expect(outcome.result).toBe(expected.result);
+      });
+    }
+  );
+});
+
+// ========================================================================
+// Concurrency contract (C1-C3)
+// ========================================================================
+
+describe("Auth Contract: Concurrency / Timing", () => {
+  it("C1: 두 요청이 동시에 401 → refresh는 1번만 호출된다 (dedup)", async () => {
+    // 두 원요청 401 → refresh 200 → 두 원요청 retry 200
+    mockFetch
+      .mockReturnValueOnce(Promise.resolve(new Response(null, { status: 401 })))
+      .mockReturnValueOnce(Promise.resolve(new Response(null, { status: 401 })))
+      .mockReturnValueOnce(
+        Promise.resolve(new Response(JSON.stringify({}), { status: 200 }))
+      )
+      .mockReturnValueOnce(
+        Promise.resolve(new Response(JSON.stringify({ a: 1 }), { status: 200 }))
+      )
+      .mockReturnValueOnce(
+        Promise.resolve(new Response(JSON.stringify({ b: 2 }), { status: 200 }))
+      );
+
+    const [r1, r2] = await Promise.all([
+      apiClient("/v2/users/me"),
+      apiClient("/v2/users/other"),
+    ]);
+
+    expect(r1).toBeDefined();
+    expect(r2).toBeDefined();
+
+    const refreshCalls = mockFetch.mock.calls.filter(
+      ([url]) => typeof url === "string" && url.includes("/api/auth/refresh")
+    ).length;
+    expect(refreshCalls).toBe(1);
+  });
+
+  it("C2: cooldown 내 재시도 → refresh 호출되지 않고 forceLogout 재발행 없음", async () => {
+    // 첫 요청: 원요청 401 → refresh 401 → forceLogout 1회
+    mockFetch
+      .mockReturnValueOnce(Promise.resolve(new Response(null, { status: 401 })))
+      .mockReturnValueOnce(Promise.resolve(new Response(null, { status: 401 })));
+
+    const { handler, detach } = withForceLogoutHandler();
+
+    await apiClient("/v2/users/me").catch(() => undefined);
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    // 1초 후 재시도 → cooldown 범위(5초) 내이므로 refresh 차단, forceLogout 추가 발행 없음
+    jest.advanceTimersByTime(1000);
+    mockFetch.mockClear();
+    mockFetch.mockReturnValueOnce(Promise.resolve(new Response(null, { status: 401 })));
+
+    await apiClient("/v2/users/me").catch(() => undefined);
+
+    const refreshCallsInSecondAttempt = mockFetch.mock.calls.filter(
+      ([url]) => typeof url === "string" && url.includes("/api/auth/refresh")
+    ).length;
+    expect(refreshCallsInSecondAttempt).toBe(0);
+    expect(handler).toHaveBeenCalledTimes(1); // 증가 없음
+    detach();
+  });
+
+  it("C3: cooldown 만료 후 재시도 → refresh 다시 호출된다", async () => {
+    mockFetch
+      .mockReturnValueOnce(Promise.resolve(new Response(null, { status: 401 })))
+      .mockReturnValueOnce(Promise.resolve(new Response(null, { status: 401 })));
+
+    await apiClient("/v2/users/me").catch(() => undefined);
+
+    jest.advanceTimersByTime(5001); // cooldown 경과
+
+    mockFetch.mockClear();
+    mockFetch
+      .mockReturnValueOnce(Promise.resolve(new Response(null, { status: 401 })))
+      .mockReturnValueOnce(Promise.resolve(new Response(null, { status: 401 })));
+
+    await apiClient("/v2/users/me").catch(() => undefined);
+
+    const refreshCalls = mockFetch.mock.calls.filter(
+      ([url]) => typeof url === "string" && url.includes("/api/auth/refresh")
+    ).length;
+    expect(refreshCalls).toBe(1);
+  });
+});
+
+// ========================================================================
+// Edge cases (E1-E2)
+// ========================================================================
+
+describe("Auth Contract: Edge cases", () => {
+  it("E1: refresh 200 성공 후 retry가 401이면 ApiError 반환하지만 forceLogout은 없다", async () => {
+    // 원요청 401 → refresh 200 → retry 401
+    mockFetch
+      .mockReturnValueOnce(Promise.resolve(new Response(null, { status: 401 })))
+      .mockReturnValueOnce(Promise.resolve(new Response(JSON.stringify({}), { status: 200 })))
+      .mockReturnValueOnce(Promise.resolve(new Response(null, { status: 401 })));
+
+    const { handler, detach } = withForceLogoutHandler();
+
+    let caught: any;
+    await apiClient("/v2/users/me").catch((e) => (caught = e));
+
+    expect(caught?.status).toBe(401);
+    expect(handler).not.toHaveBeenCalled();
+    detach();
+  });
+
+  it("E2: refresh fetch가 네트워크 에러면 silent 여부에 따라 forceLogout 분기 (non-silent)", async () => {
+    // silent=false (required): 원요청 401 → refresh network error → forceLogout 발행
+    mockFetch
+      .mockReturnValueOnce(Promise.resolve(new Response(null, { status: 401 })))
+      .mockRejectedValueOnce(new Error("Network error"));
+
+    const { handler, detach } = withForceLogoutHandler();
+
+    await apiClient("/v2/users/me").catch(() => undefined);
+    expect(handler).toHaveBeenCalled();
+    detach();
+  });
+
+  it("E2-silent: silent=true면 refresh network error에도 forceLogout 없음", async () => {
+    mockFetch
+      .mockReturnValueOnce(Promise.resolve(new Response(null, { status: 401 })))
+      .mockRejectedValueOnce(new Error("Network error"));
+
+    const { handler, detach } = withForceLogoutHandler();
+
+    await apiClient("/v2/recipes/x/status", { silentOn401: true }).catch(
+      () => undefined
+    );
+
+    expect(handler).not.toHaveBeenCalled();
+    detach();
+  });
+});
+
+// ========================================================================
+// getRecipeStatus end-to-end (엔드포인트 선언부가 silentOn401을 유지하는지 검증)
+// ========================================================================
+
+describe("Auth Contract: getRecipeStatus/getRecipesStatus 선언부 검증", () => {
+  it("getRecipeStatus는 익명 사용자에게 forceLogout을 발행하지 않는다", async () => {
+    mockFetch
+      .mockReturnValueOnce(Promise.resolve(new Response(null, { status: 401 })))
+      .mockReturnValueOnce(Promise.resolve(new Response(null, { status: 401 })));
+
+    const { handler, detach } = withForceLogoutHandler();
+    const { getRecipeStatus } = require("@/entities/recipe/model/api");
+
+    await getRecipeStatus("test-id").catch(() => undefined);
+
+    expect(handler).not.toHaveBeenCalled();
+    detach();
+  });
+
+  it("getRecipesStatus (배치)도 동일하게 익명에서 toast 없음", async () => {
+    mockFetch
+      .mockReturnValueOnce(Promise.resolve(new Response(null, { status: 401 })))
+      .mockReturnValueOnce(Promise.resolve(new Response(null, { status: 401 })));
+
+    const { handler, detach } = withForceLogoutHandler();
+    const { getRecipesStatus } = require("@/entities/recipe/model/api");
+
+    await getRecipesStatus(["a", "b"]).catch(() => undefined);
+
+    expect(handler).not.toHaveBeenCalled();
+    detach();
+  });
+});

--- a/src/shared/api/__tests__/auth-contract.test.ts
+++ b/src/shared/api/__tests__/auth-contract.test.ts
@@ -61,7 +61,7 @@ const CONTRACT: ContractRow[] = [
   {
     state: "ANONYMOUS",
     endpoint: "required",
-    expected: { forceLogout: true, refreshCalls: 1, retry: false, result: "apiError401" },
+    expected: { forceLogout: false, refreshCalls: 1, retry: false, result: "apiError401" },
   },
   // VALID row
   {
@@ -104,7 +104,7 @@ const CONTRACT: ContractRow[] = [
   {
     state: "BOTH_EXPIRED",
     endpoint: "optional-auth",
-    expected: { forceLogout: false, refreshCalls: 1, retry: false, result: "apiError401" },
+    expected: { forceLogout: true, refreshCalls: 1, retry: false, result: "apiError401" },
   },
   {
     state: "BOTH_EXPIRED",
@@ -252,8 +252,8 @@ describe("Auth Contract: Edge cases", () => {
     detach();
   });
 
-  it("E2: refresh fetch가 네트워크 에러면 silent 여부에 따라 forceLogout 분기 (non-silent)", async () => {
-    // silent=false (required): 원요청 401 → refresh network error → forceLogout 발행
+  it("E2: refresh fetch가 네트워크 에러면 forceLogout을 발행한다", async () => {
+    // 원요청 401 → refresh network error → forceLogout 발행
     mockFetch
       .mockReturnValueOnce(Promise.resolve(new Response(null, { status: 401 })))
       .mockRejectedValueOnce(new Error("Network error"));
@@ -264,30 +264,23 @@ describe("Auth Contract: Edge cases", () => {
     expect(handler).toHaveBeenCalled();
     detach();
   });
-
-  it("E2-silent: silent=true면 refresh network error에도 forceLogout 없음", async () => {
-    mockFetch
-      .mockReturnValueOnce(Promise.resolve(new Response(null, { status: 401 })))
-      .mockRejectedValueOnce(new Error("Network error"));
-
-    const { handler, detach } = withForceLogoutHandler();
-
-    await apiClient("/v2/recipes/x/status").catch(() => undefined);
-
-    expect(handler).not.toHaveBeenCalled();
-    detach();
-  });
 });
 
 // ========================================================================
-// getRecipeStatus end-to-end (엔드포인트 선언부가 silentOn401을 유지하는지 검증)
+// getRecipeStatus end-to-end (익명 사용자에게 forceLogout 없음 검증)
 // ========================================================================
 
 describe("Auth Contract: getRecipeStatus/getRecipesStatus 선언부 검증", () => {
   it("getRecipeStatus는 익명 사용자에게 forceLogout을 발행하지 않는다", async () => {
     mockFetch
       .mockReturnValueOnce(Promise.resolve(new Response(null, { status: 401 })))
-      .mockReturnValueOnce(Promise.resolve(new Response(null, { status: 401 })));
+      .mockReturnValueOnce(
+        Promise.resolve(
+          new Response(JSON.stringify({ error: "No refresh token available" }), {
+            status: 401,
+          })
+        )
+      );
 
     const { handler, detach } = withForceLogoutHandler();
     const { getRecipeStatus } = require("@/entities/recipe/model/api");
@@ -301,7 +294,13 @@ describe("Auth Contract: getRecipeStatus/getRecipesStatus 선언부 검증", () 
   it("getRecipesStatus (배치)도 동일하게 익명에서 toast 없음", async () => {
     mockFetch
       .mockReturnValueOnce(Promise.resolve(new Response(null, { status: 401 })))
-      .mockReturnValueOnce(Promise.resolve(new Response(null, { status: 401 })));
+      .mockReturnValueOnce(
+        Promise.resolve(
+          new Response(JSON.stringify({ error: "No refresh token available" }), {
+            status: 401,
+          })
+        )
+      );
 
     const { handler, detach } = withForceLogoutHandler();
     const { getRecipesStatus } = require("@/entities/recipe/model/api");
@@ -309,6 +308,64 @@ describe("Auth Contract: getRecipeStatus/getRecipesStatus 선언부 검증", () 
     await getRecipesStatus(["a", "b"]).catch(() => undefined);
 
     expect(handler).not.toHaveBeenCalled();
+    detach();
+  });
+});
+
+// ========================================================================
+// 라우트 무관 anonymous silent 검증
+// 계약의 핵심: 익명 사용자는 어떤 엔드포인트를 때리든 토스트 없음.
+// silentOn401 per-request 옵션 없이 refresh response body 시그널만으로 성립.
+// ========================================================================
+
+describe("Auth Contract: Route-agnostic anonymous silence", () => {
+  const anonymousRefreshSetup = () => {
+    mockFetch
+      .mockReturnValueOnce(Promise.resolve(new Response(null, { status: 401 })))
+      .mockReturnValueOnce(
+        Promise.resolve(
+          new Response(JSON.stringify({ error: "No refresh token available" }), {
+            status: 401,
+          })
+        )
+      );
+  };
+
+  it("익명 사용자가 required 라우트(/v2/users/me)를 때려도 forceLogout 없음", async () => {
+    anonymousRefreshSetup();
+    const { handler, detach } = withForceLogoutHandler();
+
+    await apiClient("/v2/users/me").catch(() => undefined);
+
+    expect(handler).not.toHaveBeenCalled();
+    detach();
+  });
+
+  it("익명 사용자가 optional-auth 라우트(/v2/recipes/x/status)를 때려도 forceLogout 없음", async () => {
+    anonymousRefreshSetup();
+    const { handler, detach } = withForceLogoutHandler();
+
+    await apiClient("/v2/recipes/x/status").catch(() => undefined);
+
+    expect(handler).not.toHaveBeenCalled();
+    detach();
+  });
+
+  it("진짜 만료 사용자는 어떤 라우트든 forceLogout 발행", async () => {
+    mockFetch
+      .mockReturnValueOnce(Promise.resolve(new Response(null, { status: 401 })))
+      .mockReturnValueOnce(
+        Promise.resolve(
+          new Response(JSON.stringify({ error: "Token refresh failed" }), {
+            status: 401,
+          })
+        )
+      );
+    const { handler, detach } = withForceLogoutHandler();
+
+    await apiClient("/v2/recipes/x/status").catch(() => undefined);
+
+    expect(handler).toHaveBeenCalled();
     detach();
   });
 });

--- a/src/shared/api/__tests__/auth-contract.test.ts
+++ b/src/shared/api/__tests__/auth-contract.test.ts
@@ -129,9 +129,7 @@ describe("Auth Contract: State × Endpoint matrix", () => {
 
         let apiResult: { success: true; data: any } | { success: false; error: any };
         try {
-          const data = await apiClient(spec.url, {
-            silentOn401: spec.silentOn401,
-          });
+          const data = await apiClient(spec.url);
           apiResult = { success: true, data };
         } catch (error) {
           apiResult = { success: false, error };
@@ -274,9 +272,7 @@ describe("Auth Contract: Edge cases", () => {
 
     const { handler, detach } = withForceLogoutHandler();
 
-    await apiClient("/v2/recipes/x/status", { silentOn401: true }).catch(
-      () => undefined
-    );
+    await apiClient("/v2/recipes/x/status").catch(() => undefined);
 
     expect(handler).not.toHaveBeenCalled();
     detach();

--- a/src/shared/api/__tests__/auth.test.ts
+++ b/src/shared/api/__tests__/auth.test.ts
@@ -37,9 +37,7 @@ if (typeof globalThis.Response === "undefined") {
 // auth.ts 모듈의 내부 상태(refreshPromise, lastRefreshFailTime)를 리셋하려면
 // 매 테스트마다 모듈을 새로 로드해야 함
 let refreshToken: typeof import("../auth").refreshToken;
-let handle401Error: typeof import("../auth").handle401Error;
 let performLogout: typeof import("../auth").performLogout;
-let requiresAuth: typeof import("../auth").requiresAuth;
 let dispatchForceLogoutEvent: typeof import("../auth").dispatchForceLogoutEvent;
 
 beforeEach(() => {
@@ -49,9 +47,7 @@ beforeEach(() => {
 
   const authModule = require("../auth");
   refreshToken = authModule.refreshToken;
-  handle401Error = authModule.handle401Error;
   performLogout = authModule.performLogout;
-  requiresAuth = authModule.requiresAuth;
   dispatchForceLogoutEvent = authModule.dispatchForceLogoutEvent;
 });
 
@@ -66,19 +62,6 @@ const errorResponse = (status = 401) =>
   Promise.resolve(new Response(null, { status, statusText: "Unauthorized" }));
 
 describe("refreshToken", () => {
-  it("리프레시 성공 시 true를 반환한다", async () => {
-    mockFetch.mockReturnValueOnce(okResponse());
-
-    const result = await refreshToken();
-
-    expect(result).toBe(true);
-    expect(mockFetch).toHaveBeenCalledWith("/api/auth/refresh", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      credentials: "include",
-    });
-  });
-
   it("리프레시 성공 시 tokenRefreshed 이벤트를 발행한다", async () => {
     mockFetch.mockReturnValueOnce(okResponse());
     const handler = jest.fn();
@@ -88,18 +71,6 @@ describe("refreshToken", () => {
 
     expect(handler).toHaveBeenCalled();
     window.removeEventListener("tokenRefreshed", handler);
-  });
-
-  it("리프레시 실패 시 false를 반환하고 forceLogout 이벤트를 발행한다", async () => {
-    mockFetch.mockReturnValueOnce(errorResponse());
-    const handler = jest.fn();
-    window.addEventListener("forceLogout", handler);
-
-    const result = await refreshToken();
-
-    expect(result).toBe(false);
-    expect(handler).toHaveBeenCalled();
-    window.removeEventListener("forceLogout", handler);
   });
 
   it("네트워크 에러 시 false를 반환한다", async () => {
@@ -171,42 +142,6 @@ describe("refreshToken", () => {
   });
 });
 
-describe("handle401Error", () => {
-  it("리프레시 성공 시 원래 요청을 재시도한다", async () => {
-    mockFetch.mockReturnValueOnce(okResponse()); // refresh
-    const retryResponse = new Response(JSON.stringify({ data: "ok" }), {
-      status: 200,
-    });
-    const originalRequest = jest.fn().mockResolvedValueOnce(retryResponse);
-
-    const result = await handle401Error(originalRequest);
-
-    expect(result).toBe(retryResponse);
-    expect(originalRequest).toHaveBeenCalledTimes(1);
-  });
-
-  it("리프레시 실패 시 null을 반환한다", async () => {
-    mockFetch.mockReturnValueOnce(errorResponse());
-    const originalRequest = jest.fn();
-
-    const result = await handle401Error(originalRequest);
-
-    expect(result).toBeNull();
-    expect(originalRequest).not.toHaveBeenCalled();
-  });
-
-  it("리프레시 성공했지만 재시도가 실패하면 null을 반환한다", async () => {
-    mockFetch.mockReturnValueOnce(okResponse()); // refresh
-    const originalRequest = jest
-      .fn()
-      .mockRejectedValueOnce(new Error("retry failed"));
-
-    const result = await handle401Error(originalRequest);
-
-    expect(result).toBeNull();
-  });
-});
-
 describe("performLogout", () => {
   it("로그아웃 성공 시 true를 반환한다", async () => {
     mockFetch.mockReturnValueOnce(okResponse());
@@ -230,23 +165,6 @@ describe("performLogout", () => {
     const result = await performLogout();
 
     expect(result).toBe(false);
-  });
-});
-
-describe("requiresAuth", () => {
-  it("public 엔드포인트는 false를 반환한다", () => {
-    expect(requiresAuth("/auth/login")).toBe(false);
-    expect(requiresAuth("/auth/register")).toBe(false);
-    expect(requiresAuth("/auth/refresh")).toBe(false);
-    expect(requiresAuth("/recipes/public")).toBe(false);
-    expect(requiresAuth("/users/public")).toBe(false);
-    expect(requiresAuth("/health")).toBe(false);
-  });
-
-  it("인증이 필요한 엔드포인트는 true를 반환한다", () => {
-    expect(requiresAuth("/recipes/123")).toBe(true);
-    expect(requiresAuth("/users/me")).toBe(true);
-    expect(requiresAuth("/comments")).toBe(true);
   });
 });
 

--- a/src/shared/api/auth.ts
+++ b/src/shared/api/auth.ts
@@ -18,9 +18,16 @@ export const dispatchForceLogoutEvent = (reason: string, message?: string) => {
   }
 };
 
-let refreshPromise: Promise<boolean> | null = null;
+type RefreshResult = "success" | "no_session" | "expired" | "network_error";
+
+let refreshPromise: Promise<RefreshResult> | null = null;
 let lastRefreshFailTime = 0;
 const REFRESH_COOLDOWN_MS = 5000;
+
+// /api/auth/refresh route가 쿠키 없음을 감지해 내려주는 body error 메시지.
+// 이 시그널이 오면 "한 번도 로그인 안 한 사용자"로 간주해 forceLogout dispatch를 스킵한다.
+// 계약 정의: docs/auth-contract.md (Refresh response discrimination)
+const NO_SESSION_ERROR_MESSAGE = "No refresh token available";
 
 const logAuth = (event: string, data?: Record<string, unknown>) => {
   if (isClient) {
@@ -36,21 +43,14 @@ const logAuth = (event: string, data?: Record<string, unknown>) => {
   }
 };
 
-type RefreshOptions = { silent?: boolean };
-
-export const refreshToken = async (
-  options: RefreshOptions = {}
-): Promise<boolean> => {
-  const { silent = false } = options;
-
+export const refreshToken = async (): Promise<boolean> => {
   const now = Date.now();
   if (now - lastRefreshFailTime < REFRESH_COOLDOWN_MS) {
     logAuth("refresh-blocked-cooldown", {
       remainingMs: REFRESH_COOLDOWN_MS - (now - lastRefreshFailTime),
-      silent,
     });
-    // cooldown은 이전 실제 실패에서 발생 — 그때 이미 dispatch됐거나 의도적으로
-    // silent였던 것. 여기서 재발행하면 중복.
+    // cooldown 경로는 이전 실제 실패/no_session 때 이미 결정이 내려진 상태.
+    // 여기서 재발행하지 않는다 (중복 방지).
     return false;
   }
 
@@ -62,13 +62,15 @@ export const refreshToken = async (
 
   try {
     const result = await ongoing;
-    if (!result) {
-      lastRefreshFailTime = Date.now();
-      if (!silent) {
-        dispatchForceLogoutEvent("REFRESH_TOKEN_EXPIRED");
-      }
+    if (result === "success") {
+      return true;
     }
-    return result;
+    lastRefreshFailTime = Date.now();
+    if (result === "expired" || result === "network_error") {
+      dispatchForceLogoutEvent("REFRESH_TOKEN_EXPIRED");
+    }
+    // "no_session"은 조용히 실패 — 쿠키가 애초에 없는 사용자라 "로그인 만료"는 거짓말.
+    return false;
   } finally {
     if (refreshPromise === ongoing) {
       refreshPromise = null;
@@ -76,7 +78,7 @@ export const refreshToken = async (
   }
 };
 
-const performTokenRefresh = async (): Promise<boolean> => {
+const performTokenRefresh = async (): Promise<RefreshResult> => {
   logAuth("refresh-start");
 
   try {
@@ -88,24 +90,31 @@ const performTokenRefresh = async (): Promise<boolean> => {
       credentials: "include",
     });
 
-    if (!response.ok) {
-      logAuth("refresh-failed", { status: response.status });
-      return false;
+    if (response.ok) {
+      logAuth("refresh-success");
+      if (isClient) {
+        const event = new CustomEvent("tokenRefreshed");
+        window.dispatchEvent(event);
+      }
+      return "success";
     }
 
-    logAuth("refresh-success");
+    const body = await response.json().catch(() => null);
+    const isNoSession =
+      response.status === 401 && body?.error === NO_SESSION_ERROR_MESSAGE;
 
-    if (isClient) {
-      const event = new CustomEvent("tokenRefreshed");
-      window.dispatchEvent(event);
+    if (isNoSession) {
+      logAuth("refresh-no-session");
+      return "no_session";
     }
 
-    return true;
+    logAuth("refresh-expired", { status: response.status });
+    return "expired";
   } catch (error) {
-    logAuth("refresh-error", {
+    logAuth("refresh-network-error", {
       error: error instanceof Error ? error.message : String(error),
     });
-    return false;
+    return "network_error";
   }
 };
 
@@ -142,13 +151,10 @@ export const requiresAuth = (url: string): boolean => {
   return !publicEndpoints.some((endpoint) => url.includes(endpoint));
 };
 
-type Handle401Options = { silent?: boolean };
-
 export const handle401Error = async (
-  originalRequest: () => Promise<Response>,
-  options: Handle401Options = {}
+  originalRequest: () => Promise<Response>
 ): Promise<Response | null> => {
-  const refreshed = await refreshToken({ silent: options.silent });
+  const refreshed = await refreshToken();
 
   if (refreshed) {
     try {

--- a/src/shared/api/auth.ts
+++ b/src/shared/api/auth.ts
@@ -36,29 +36,43 @@ const logAuth = (event: string, data?: Record<string, unknown>) => {
   }
 };
 
-export const refreshToken = async (): Promise<boolean> => {
+type RefreshOptions = { silent?: boolean };
+
+export const refreshToken = async (
+  options: RefreshOptions = {}
+): Promise<boolean> => {
+  const { silent = false } = options;
+
   const now = Date.now();
   if (now - lastRefreshFailTime < REFRESH_COOLDOWN_MS) {
     logAuth("refresh-blocked-cooldown", {
       remainingMs: REFRESH_COOLDOWN_MS - (now - lastRefreshFailTime),
+      silent,
     });
+    // cooldown은 이전 실제 실패에서 발생 — 그때 이미 dispatch됐거나 의도적으로
+    // silent였던 것. 여기서 재발행하면 중복.
     return false;
   }
 
-  if (refreshPromise) {
-    return refreshPromise;
+  if (!refreshPromise) {
+    refreshPromise = performTokenRefresh();
   }
 
-  refreshPromise = performTokenRefresh();
+  const ongoing = refreshPromise;
 
   try {
-    const result = await refreshPromise;
+    const result = await ongoing;
     if (!result) {
       lastRefreshFailTime = Date.now();
+      if (!silent) {
+        dispatchForceLogoutEvent("REFRESH_TOKEN_EXPIRED");
+      }
     }
     return result;
   } finally {
-    refreshPromise = null;
+    if (refreshPromise === ongoing) {
+      refreshPromise = null;
+    }
   }
 };
 
@@ -76,7 +90,7 @@ const performTokenRefresh = async (): Promise<boolean> => {
 
     if (!response.ok) {
       logAuth("refresh-failed", { status: response.status });
-      throw new Error(`Token refresh failed: ${response.statusText}`);
+      return false;
     }
 
     logAuth("refresh-success");
@@ -88,10 +102,9 @@ const performTokenRefresh = async (): Promise<boolean> => {
 
     return true;
   } catch (error) {
-    logAuth("refresh-error-forceLogout", {
+    logAuth("refresh-error", {
       error: error instanceof Error ? error.message : String(error),
     });
-    dispatchForceLogoutEvent("REFRESH_TOKEN_EXPIRED");
     return false;
   }
 };
@@ -129,10 +142,13 @@ export const requiresAuth = (url: string): boolean => {
   return !publicEndpoints.some((endpoint) => url.includes(endpoint));
 };
 
+type Handle401Options = { silent?: boolean };
+
 export const handle401Error = async (
-  originalRequest: () => Promise<Response>
+  originalRequest: () => Promise<Response>,
+  options: Handle401Options = {}
 ): Promise<Response | null> => {
-  const refreshed = await refreshToken();
+  const refreshed = await refreshToken({ silent: options.silent });
 
   if (refreshed) {
     try {

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -18,6 +18,7 @@ export async function apiClient<T = any>(
     baseURL,
     headers = {},
     paramsSerializer,
+    silentOn401 = false,
     ...restOptions
   } = options;
 
@@ -72,7 +73,9 @@ export async function apiClient<T = any>(
           .map((c) => c.trim().split("=")[0])
           .filter(Boolean),
       });
-      const retryResponse = await handle401Error(executeRequest);
+      const retryResponse = await handle401Error(executeRequest, {
+        silent: silentOn401,
+      });
       if (retryResponse) {
         console.log("[Auth] 401-retry-success", { url });
         response = retryResponse;

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -18,7 +18,6 @@ export async function apiClient<T = any>(
     baseURL,
     headers = {},
     paramsSerializer,
-    silentOn401 = false,
     ...restOptions
   } = options;
 
@@ -73,9 +72,7 @@ export async function apiClient<T = any>(
           .map((c) => c.trim().split("=")[0])
           .filter(Boolean),
       });
-      const retryResponse = await handle401Error(executeRequest, {
-        silent: silentOn401,
-      });
+      const retryResponse = await handle401Error(executeRequest);
       if (retryResponse) {
         console.log("[Auth] 401-retry-success", { url });
         response = retryResponse;

--- a/src/shared/api/types.ts
+++ b/src/shared/api/types.ts
@@ -5,6 +5,13 @@ export interface ApiRequestOptions extends RequestInit {
   timeout?: number;
   baseURL?: string;
   paramsSerializer?: (params: Record<string, any>) => string;
+  /**
+   * true면 이 요청의 401 → refresh 실패 시 forceLogout 이벤트를 발행하지 않는다.
+   * optional-auth 엔드포인트(쿠키 있으면 개인화, 없으면 공개)에 사용.
+   * refresh 시도 자체는 그대로 수행된다 — 진짜 만료 사용자는 정상 복구된다.
+   * 계약 정의: docs/auth-contract.md
+   */
+  silentOn401?: boolean;
 }
 
 export interface ApiResponse<T = any> {

--- a/src/shared/api/types.ts
+++ b/src/shared/api/types.ts
@@ -5,13 +5,6 @@ export interface ApiRequestOptions extends RequestInit {
   timeout?: number;
   baseURL?: string;
   paramsSerializer?: (params: Record<string, any>) => string;
-  /**
-   * true면 이 요청의 401 → refresh 실패 시 forceLogout 이벤트를 발행하지 않는다.
-   * optional-auth 엔드포인트(쿠키 있으면 개인화, 없으면 공개)에 사용.
-   * refresh 시도 자체는 그대로 수행된다 — 진짜 만료 사용자는 정상 복구된다.
-   * 계약 정의: docs/auth-contract.md
-   */
-  silentOn401?: boolean;
 }
 
 export interface ApiResponse<T = any> {

--- a/src/shared/lib/metadata/homeMetadata.ts
+++ b/src/shared/lib/metadata/homeMetadata.ts
@@ -2,10 +2,26 @@ import type { Metadata } from "next";
 
 import { SEO_CONSTANTS } from "./constants";
 
+const HOME_DESCRIPTION =
+  "YouTube 링크 하나로 레시피 저장, 30,000+ 홈쿡 레시피 · AI 맞춤 추천 · 홈파티·기념일·다이어트 상황별 레시피까지 한번에.";
+
+const HOME_EXTRA_KEYWORDS = [
+  "YouTube 레시피",
+  "유튜브 레시피 추출",
+  "유튜브 레시피 저장",
+  "홈파티",
+  "기념일 요리",
+  "집들이 음식",
+  "자취 요리",
+  "다이어트 레시피",
+  "냉장고 재료 레시피",
+  "AI 레시피 추천",
+];
+
 export const homeMetadata: Metadata = {
   title: `${SEO_CONSTANTS.SITE_NAME} - AI가 추천하는 홈쿡 레시피`,
-  description: `AI가 추천하는 맛있는 홈쿡 레시피로 집에서 간편하게 요리해보세요. 이번주 인기 레시피와 홈파티 레시피까지!`,
-  keywords: [...SEO_CONSTANTS.DEFAULT_KEYWORDS, "홈파티"],
+  description: HOME_DESCRIPTION,
+  keywords: [...SEO_CONSTANTS.DEFAULT_KEYWORDS, ...HOME_EXTRA_KEYWORDS],
   verification: {
     other: {
       "naver-site-verification": "7c2a4d7a2d320196a11bcf8e31524a1827f41b99",
@@ -16,7 +32,7 @@ export const homeMetadata: Metadata = {
   },
   openGraph: {
     title: "레시피오",
-    description: "AI가 추천하는 홈쿡 레시피로 집에서 맛있게 해먹어보세요!",
+    description: HOME_DESCRIPTION,
     url: "https://www.recipio.kr/",
     siteName: "레시피오 - recipio",
     images: [
@@ -33,8 +49,7 @@ export const homeMetadata: Metadata = {
   twitter: {
     card: SEO_CONSTANTS.TWITTER_CARD,
     title: `${SEO_CONSTANTS.SITE_NAME} - AI가 추천하는 홈쿡 레시피`,
-    description:
-      "AI가 추천하는 맛있는 홈쿡 레시피로 집에서 간편하게 요리해보세요.",
+    description: HOME_DESCRIPTION,
     images: [SEO_CONSTANTS.DEFAULT_IMAGE],
   },
 };

--- a/src/shared/lib/metadata/structuredData.ts
+++ b/src/shared/lib/metadata/structuredData.ts
@@ -1,5 +1,7 @@
 // Re-export from entities/recipe for backward compatibility
 export {
+  createLandingFAQStructuredData,
   createRecipeStructuredData,
+  createTagItemListStructuredData,
   createWebsiteStructuredData,
 } from "@/entities/recipe/lib/metadata/schema";

--- a/src/widgets/Header/SavedRecipeBooksButton.tsx
+++ b/src/widgets/Header/SavedRecipeBooksButton.tsx
@@ -1,14 +1,30 @@
 "use client";
 
+import type { MouseEvent } from "react";
 import Link from "next/link";
 
 import { Bookmark } from "lucide-react";
 
 import { triggerHaptic } from "@/shared/lib/bridge";
 
+import { useUserStore } from "@/entities/user/model/store";
+
+import { useLoginEncourageDrawerStore } from "@/widgets/LoginEncourageDrawer/model/store";
+
 const SavedRecipeBooksButton = () => {
-  const handleClick = () => {
+  const { user } = useUserStore();
+  const { openDrawer } = useLoginEncourageDrawerStore();
+
+  const handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
     triggerHaptic("Light");
+
+    if (!user) {
+      e.preventDefault();
+      openDrawer({
+        icon: <Bookmark size={24} className="text-olive-light" />,
+        message: "저장한 레시피북을 확인해보세요!",
+      });
+    }
   };
 
   return (

--- a/src/widgets/LoginEncourageDrawer/model/store.ts
+++ b/src/widgets/LoginEncourageDrawer/model/store.ts
@@ -15,8 +15,12 @@ export const useLoginEncourageDrawerStore = create<LoginEncourageDrawerStore>(
     isOpen: false,
     icon: undefined,
     message: undefined,
-    openDrawer: (options) => set({ isOpen: true, ...options }),
-    closeDrawer: () =>
-      set({ isOpen: false, icon: undefined, message: undefined }),
+    openDrawer: (options) =>
+      set({
+        isOpen: true,
+        icon: options?.icon,
+        message: options?.message,
+      }),
+    closeDrawer: () => set({ isOpen: false }),
   })
 );


### PR DESCRIPTION
This pull request introduces a comprehensive "Auth Contract" specification and regression lock for authentication behavior, along with improvements to analytics pageview tracking and related tests. The changes ensure that authentication flows are consistently enforced and tested, and that analytics events are not duplicated on redundant navigation events.

**Key changes:**

### Authentication Contract & Testing

* Added a detailed `docs/auth-contract.md` document that defines the authoritative contract for authentication behavior, covering session states, endpoint kinds, refresh response handling, a contract matrix, concurrency/timing, edge cases, and regression lock with explicit test mapping. This document acts as the single source of truth for auth logic and its test coverage.
* Introduced a new harness in `src/shared/api/__tests__/_auth-harness.ts` to simulate all combinations of session state and endpoint kind, enabling robust and maintainable contract tests that directly reference the new spec.
* Added clarifying comments in `src/entities/recipe/model/api.ts` to document how optional-auth endpoints rely on the refresh response signal for correct forceLogout behavior, referencing the contract.

### Analytics (PostHog) Pageview Tracking

* Implemented a pageview guard in `src/app/providers/posthogPageviewGuard.ts` to prevent duplicate `$pageview` events for the same URL, ensuring only the first navigation to a URL is tracked until the URL changes.
* Updated `PostHogPageView.tsx` to use the new guard, capturing pageviews only when appropriate.
* Removed the initial `$pageview` event from the PostHog provider's `loaded` callback to avoid double-counting.
* Added unit tests for the pageview guard to verify correct behavior across navigation scenarios.

These changes significantly improve the reliability of authentication flows and analytics tracking, and establish a strong foundation for regression prevention and future maintenance.

(Auth Contract: [[1]](diffhunk://#diff-8070430d985a83466e81c2eb494b12155618e3535d22840f83db01a33274f064R1-R137) [[2]](diffhunk://#diff-322b578c479419190c795c1219b1744134040800b21869e3daab5f05c9c394e9R1-R187) [[3]](diffhunk://#diff-0f8d8c24ceb891fe2d5cbda8e8e5f447b9062cb0f260a0410acae7e95597f780R107-R109)
(PostHog Pageview Guard: [[1]](diffhunk://#diff-862f3a1e275c115029d230b960416f8db48bb73344b4f6e0cacdeacdce85616dR1-R11) [[2]](diffhunk://#diff-815c5add371c887be76aa389a7b835ace353b9b361f0754b98d1e0b42ffe9a1fR8-L21) [[3]](diffhunk://#diff-09b50576ce107a2d0c2b700fff6249293474dfd9cc0debee9068ba524cf9663dL32-L34) [[4]](diffhunk://#diff-658ae790432f5ba852ada0564d1059f796f89d3c645587d7f01a822b97667e6eR1-R48)